### PR TITLE
[JENKINS-20784] - Avoid user's creation in TriggeringUsersAuthorizationStrategy

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/authorizeproject/strategy/TriggeringUsersAuthorizationStrategy.java
+++ b/src/main/java/org/jenkinsci/plugins/authorizeproject/strategy/TriggeringUsersAuthorizationStrategy.java
@@ -34,6 +34,7 @@ import hudson.model.AbstractProject;
 import hudson.model.Descriptor;
 import hudson.model.Run;
 import hudson.model.User;
+import java.util.Collections;
 
 import org.acegisecurity.Authentication;
 import org.jenkinsci.plugins.authorizeproject.AuthorizeProjectStrategy;
@@ -60,7 +61,7 @@ public class TriggeringUsersAuthorizationStrategy extends AuthorizeProjectStrate
     public Authentication authenticate(AbstractProject<?, ?> project, Queue.Item item) {
         Cause.UserIdCause cause = getRootUserIdCause(item);
         if (cause != null) {
-            User u = User.get(cause.getUserId());
+            User u = User.get(cause.getUserId(), false, Collections.emptyMap());
             if (u == null) {
                 return Jenkins.ANONYMOUS;
             }


### PR DESCRIPTION
Bad guys can insert everything to UserIdCause, so it is preferable to have such check.
Related to https://issues.jenkins-ci.org/browse/JENKINS-20784

Signed-off-by: Oleg Nenashev nenashev@synopsys.com
