### PR TITLE
[JENKINS-20812] Store AuthorizeProjectStrategy global configs inside a separate folder.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/authorizeproject/AuthorizeProjectStrategyDescriptor.java
+++ b/src/main/java/org/jenkinsci/plugins/authorizeproject/AuthorizeProjectStrategyDescriptor.java
@@ -24,6 +24,7 @@
 
 package org.jenkinsci.plugins.authorizeproject;
 
+import hudson.XmlFile;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -32,11 +33,15 @@ import net.sf.json.JSONObject;
 import org.kohsuke.stapler.StaplerRequest;
 
 import hudson.model.Descriptor;
+import java.io.File;
+import jenkins.model.Jenkins;
 
 /**
  *
  */
 public abstract class AuthorizeProjectStrategyDescriptor extends Descriptor<AuthorizeProjectStrategy> {
+    
+    
     /**
      * 
      */
@@ -50,7 +55,12 @@ public abstract class AuthorizeProjectStrategyDescriptor extends Descriptor<Auth
     public AuthorizeProjectStrategyDescriptor(Class<? extends AuthorizeProjectStrategy> clazz) {
         super(clazz);
     }
-    
+
+    @Override
+    protected final XmlFile getConfigFile() {
+        return new XmlFile(new File(Jenkins.getInstance().getRootDir(),
+                Constants.CONFIG_FOLDER+"/"+getId()+".xml"));
+    }
     
     /**
      * @return return a page to shown in "Configure Global Security" as a child of {@link ProjectQueueItemAuthenticator}.

--- a/src/main/java/org/jenkinsci/plugins/authorizeproject/Constants.java
+++ b/src/main/java/org/jenkinsci/plugins/authorizeproject/Constants.java
@@ -1,0 +1,33 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2013 Oleg Nenashev
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jenkinsci.plugins.authorizeproject;
+
+/**
+ * Stores private constants of the plugin.
+ * @author Oleg Nenashev
+ */
+class Constants {
+    /**A folder, which stores configs for authorize-project plugin*/
+    static final String CONFIG_FOLDER = "authorize-project";
+}


### PR DESCRIPTION
Improves @ikedam's solution for https://issues.jenkins-ci.org/browse/JENKINS-20812

Signed-off-by: Oleg Nenashev nenashev@synopsys.com
