### PR TITLE
[FIXED JENKINS-26670] Support Job including WorkflowJob

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,6 +4,7 @@
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
     <version>1.532</version><!-- QueueItemAuthenticator is since 1.520 -->
+    <!--<version>1.580.1</version>--><!-- When you test the integration with workflow -->
   </parent>
 
   <groupId>org.jenkins-ci.plugins</groupId>
@@ -39,7 +40,32 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    <workflow.version>1.0</workflow.version>
   </properties>
+  
+  <dependencies>
+    <!-- When you test the integration with workflow -->
+    <!--
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-job</artifactId>
+      <version>${workflow.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-basic-steps</artifactId>
+      <version>${workflow.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-cps</artifactId>
+      <version>${workflow.version}</version>
+      <scope>test</scope>
+    </dependency>
+    -->
+  </dependencies>
   
   <!-- get every artifact through repo.jenkins-ci.org, which proxies all the artifacts that we need -->
   <repositories>

--- a/src/main/java/org/jenkinsci/plugins/authorizeproject/AuthorizeProjectProperty.java
+++ b/src/main/java/org/jenkinsci/plugins/authorizeproject/AuthorizeProjectProperty.java
@@ -40,14 +40,13 @@ import hudson.model.Job;
 import hudson.model.JobProperty;
 import hudson.model.JobPropertyDescriptor;
 import hudson.model.Queue;
-import hudson.model.AbstractProject;
 import hudson.model.Descriptor;
 import hudson.security.AuthorizationStrategy;
 
 /**
  * Specifies how to authorize its builds.
  */
-public class AuthorizeProjectProperty extends JobProperty<AbstractProject<?,?>> {
+public class AuthorizeProjectProperty extends JobProperty<Job<?,?>> {
     /**
      * Property name used for job configuration page.
      */
@@ -80,7 +79,7 @@ public class AuthorizeProjectProperty extends JobProperty<AbstractProject<?,?>> 
      * 
      * @param item the item in queue, which will be a build.
      * @return authorization for this build.
-     * @see AuthorizeProjectStrategy#authenticate(hudson.model.AbstractProject, hudson.model.Queue.Item)
+     * @see AuthorizeProjectStrategy#authenticate(hudson.model.Job, hudson.model.Queue.Item)
      */
     public Authentication authenticate(Queue.Item item) {
         if (getStrategy() == null) {

--- a/src/main/java/org/jenkinsci/plugins/authorizeproject/ProjectQueueItemAuthenticator.java
+++ b/src/main/java/org/jenkinsci/plugins/authorizeproject/ProjectQueueItemAuthenticator.java
@@ -28,6 +28,7 @@ import java.util.List;
 
 import hudson.Extension;
 import hudson.model.AbstractProject;
+import hudson.model.Job;
 import hudson.model.Queue;
 
 import javax.annotation.CheckForNull;
@@ -61,11 +62,13 @@ public class ProjectQueueItemAuthenticator extends QueueItemAuthenticator {
     @Override
     @CheckForNull
     public Authentication authenticate(Queue.Item item) {
-        if (!(item.task instanceof AbstractProject)) {
-            // This handles only AbstractProject.
+        if (!(item.task instanceof Job)) {
             return null;
         }
-        AbstractProject<?, ?> project = ((AbstractProject<?,?>)item.task).getRootProject();
+        Job<?, ?> project = (Job<?,?>)item.task;
+        if (project instanceof AbstractProject) {
+            project = ((AbstractProject<?,?>)project).getRootProject();
+        }
         AuthorizeProjectProperty prop = project.getProperty(AuthorizeProjectProperty.class);
         if (prop == null) {
             return null;

--- a/src/main/java/org/jenkinsci/plugins/authorizeproject/strategy/AnonymousAuthorizationStrategy.java
+++ b/src/main/java/org/jenkinsci/plugins/authorizeproject/strategy/AnonymousAuthorizationStrategy.java
@@ -26,8 +26,8 @@ package org.jenkinsci.plugins.authorizeproject.strategy;
 
 import jenkins.model.Jenkins;
 import hudson.Extension;
+import hudson.model.Job;
 import hudson.model.Queue;
-import hudson.model.AbstractProject;
 
 import org.acegisecurity.Authentication;
 import org.jenkinsci.plugins.authorizeproject.AuthorizeProjectStrategy;
@@ -51,10 +51,10 @@ public class AnonymousAuthorizationStrategy extends AuthorizeProjectStrategy {
      * @param project
      * @param item
      * @return anonymous authorization
-     * @see org.jenkinsci.plugins.authorizeproject.AuthorizeProjectStrategy#authenticate(hudson.model.AbstractProject, hudson.model.Queue.Item)
+     * @see org.jenkinsci.plugins.authorizeproject.AuthorizeProjectStrategy#authenticate(hudson.model.Job, hudson.model.Queue.Item)
      */
     @Override
-    public Authentication authenticate(AbstractProject<?, ?> project, Queue.Item item) {
+    public Authentication authenticate(Job<?, ?> project, Queue.Item item) {
         return Jenkins.ANONYMOUS;
     }
     

--- a/src/main/java/org/jenkinsci/plugins/authorizeproject/strategy/SpecificUsersAuthorizationStrategy.java
+++ b/src/main/java/org/jenkinsci/plugins/authorizeproject/strategy/SpecificUsersAuthorizationStrategy.java
@@ -38,6 +38,7 @@ import hudson.model.User;
 import hudson.model.AbstractProject;
 import hudson.model.Descriptor;
 import hudson.model.Descriptor.FormException;
+import hudson.model.Job;
 import hudson.security.ACL;
 import hudson.util.FormValidation;
 import net.sf.json.JSONObject;
@@ -96,10 +97,10 @@ public class SpecificUsersAuthorizationStrategy extends AuthorizeProjectStrategy
      * @param project
      * @param item
      * @return
-     * @see org.jenkinsci.plugins.authorizeproject.AuthorizeProjectStrategy#authenticate(hudson.model.AbstractProject, hudson.model.Queue.Item)
+     * @see org.jenkinsci.plugins.authorizeproject.AuthorizeProjectStrategy#authenticate(hudson.model.Job, hudson.model.Queue.Item)
      */
     @Override
-    public Authentication authenticate(AbstractProject<?, ?> project, Queue.Item item) {
+    public Authentication authenticate(Job<?, ?> project, Queue.Item item) {
         User u = User.get(getUserid(), false, Collections.emptyMap());
         if (u == null) {
             // fallback to anonymous
@@ -164,7 +165,7 @@ public class SpecificUsersAuthorizationStrategy extends AuthorizeProjectStrategy
      * @param project
      * @return
      */
-    protected static SpecificUsersAuthorizationStrategy getCurrentStrategy(AbstractProject<?,?> project) {
+    protected static SpecificUsersAuthorizationStrategy getCurrentStrategy(Job<?,?> project) {
         if (project == null) {
             return null;
         }
@@ -179,6 +180,11 @@ public class SpecificUsersAuthorizationStrategy extends AuthorizeProjectStrategy
         }
         
         return (SpecificUsersAuthorizationStrategy)prop.getStrategy();
+    }
+    
+    @Deprecated
+    protected static SpecificUsersAuthorizationStrategy getCurrentStrategy(AbstractProject<?,?> project) {
+        return getCurrentStrategy((Job<?,?>)project);
     }
     
     /**
@@ -315,7 +321,7 @@ public class SpecificUsersAuthorizationStrategy extends AuthorizeProjectStrategy
             SpecificUsersAuthorizationStrategy strategy = newInstanceWithoutAuthentication(req, formData);
             
             SpecificUsersAuthorizationStrategy currentStrategy
-                = getCurrentStrategy(req.findAncestorObject(AbstractProject.class));
+                = getCurrentStrategy(req.findAncestorObject(Job.class));
             
             if (isAuthenticateionRequired(strategy, currentStrategy)) {
                 if (!authenticate(strategy, req, formData)) {
@@ -354,7 +360,7 @@ public class SpecificUsersAuthorizationStrategy extends AuthorizeProjectStrategy
             SpecificUsersAuthorizationStrategy newStrategy = new SpecificUsersAuthorizationStrategy(userid, noNeedReauthentication);
             return Boolean.toString(isAuthenticateionRequired(
                     newStrategy,
-                    getCurrentStrategy(req.findAncestorObject(AbstractProject.class))
+                    getCurrentStrategy(req.findAncestorObject(Job.class))
             ));
         }
         
@@ -385,7 +391,7 @@ public class SpecificUsersAuthorizationStrategy extends AuthorizeProjectStrategy
             SpecificUsersAuthorizationStrategy newStrategy = new SpecificUsersAuthorizationStrategy(userid, noNeedReauthentication);
             if (!isAuthenticateionRequired(
                     newStrategy,
-                    getCurrentStrategy(req.findAncestorObject(AbstractProject.class))
+                    getCurrentStrategy(req.findAncestorObject(Job.class))
             )) {
                 // authentication is not required.
                 return FormValidation.ok();

--- a/src/main/java/org/jenkinsci/plugins/authorizeproject/strategy/TriggeringUsersAuthorizationStrategy.java
+++ b/src/main/java/org/jenkinsci/plugins/authorizeproject/strategy/TriggeringUsersAuthorizationStrategy.java
@@ -29,8 +29,8 @@ import hudson.Extension;
 import hudson.model.Cause;
 import hudson.model.Cause.UpstreamCause;
 import hudson.model.Cause.UserIdCause;
+import hudson.model.Job;
 import hudson.model.Queue;
-import hudson.model.AbstractProject;
 import hudson.model.Run;
 import hudson.model.User;
 import java.util.Collections;
@@ -55,10 +55,10 @@ public class TriggeringUsersAuthorizationStrategy extends AuthorizeProjectStrate
      * @param project
      * @param item
      * @return
-     * @see org.jenkinsci.plugins.authorizeproject.AuthorizeProjectStrategy#authenticate(hudson.model.AbstractProject, hudson.model.Queue.Item)
+     * @see org.jenkinsci.plugins.authorizeproject.AuthorizeProjectStrategy#authenticate(hudson.model.Job, hudson.model.Queue.Item)
      */
     @Override
-    public Authentication authenticate(AbstractProject<?, ?> project, Queue.Item item) {
+    public Authentication authenticate(Job<?, ?> project, Queue.Item item) {
         Cause.UserIdCause cause = getRootUserIdCause(item);
         if (cause != null) {
             User u = User.get(cause.getUserId(), false, Collections.emptyMap());

--- a/src/test/java/org/jenkinsci/plugins/authorizeproject/ProjectQueueItemAuthenticatorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/authorizeproject/ProjectQueueItemAuthenticatorTest.java
@@ -53,6 +53,24 @@ import com.gargoylesoftware.htmlunit.html.HtmlForm;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
 import com.gargoylesoftware.htmlunit.html.HtmlTextInput;
 
+/*
+// classes for workflowTest
+import java.io.IOException;
+import jenkins.tasks.SimpleBuildStep;
+import hudson.FilePath;
+import hudson.Launcher;
+import hudson.model.InvisibleAction;
+import hudson.model.TaskListener;
+import hudson.model.Run;
+import hudson.tasks.BuildStepDescriptor;
+import hudson.tasks.Builder;
+import org.jenkinsci.plugins.authorizeproject.strategy.SpecificUsersAuthorizationStrategy;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.kohsuke.stapler.DataBoundConstructor;
+*/
+
 /**
  *
  */
@@ -364,6 +382,7 @@ public class ProjectQueueItemAuthenticatorTest {
     
     @Test
     public void testOldSignature() throws Exception {
+        j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
         FreeStyleProject p = j.createFreeStyleProject();
         p.addProperty(new AuthorizeProjectProperty(new AuthorizeProjectStrategyWithOldSignature("test1")));
         AuthorizationCheckBuilder checker = new AuthorizationCheckBuilder();
@@ -372,4 +391,75 @@ public class ProjectQueueItemAuthenticatorTest {
         j.assertBuildStatusSuccess(p.scheduleBuild2(0));
         assertEquals("test1", checker.authentication.getName());
     }
+    
+    /*
+    // A test for workflow plugin (which extends Job, not AbstractProject).
+    // This is disabled as workflow requires Jenkins >= 1.580.1
+    // but authorize-project targets Jenkins >= 1.532.
+    public static class AuthorizationRecordAction extends InvisibleAction {
+        public final Authentication authentication;
+        
+        public AuthorizationRecordAction(Authentication authentication) {
+            this.authentication = authentication;
+        }
+    }
+    
+    public static class AuthorizationCheckSimpleBuilder extends Builder implements SimpleBuildStep {
+        @DataBoundConstructor
+        public AuthorizationCheckSimpleBuilder() {
+        }
+        
+        @Override
+        public void perform(Run<?, ?> run, FilePath workspace, Launcher launcher, TaskListener listener)
+                throws InterruptedException, IOException {
+            run.addAction(new AuthorizationRecordAction(Jenkins.getAuthentication()));
+        }
+        
+        @TestExtension("testWorkflow")
+        public static class DescriptorImpl extends BuildStepDescriptor<Builder> {
+            @Override
+            public boolean isApplicable(Class<? extends AbstractProject> jobType) {
+                return true;
+            }
+            
+            @Override
+            public String getDisplayName() {
+                return "AuthorizationCheckSimpleBuilder";
+            }
+        }
+    }
+    
+    @Test
+    public void testWorkflow() throws Exception {
+        j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
+        {
+            WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "test"+j.jenkins.getItems().size());
+            p.setDefinition(new CpsFlowDefinition("node{ step([$class: 'AuthorizationCheckSimpleBuilder']); }", true));
+            WorkflowRun b = p.scheduleBuild2(0).get();
+            j.assertBuildStatusSuccess(b);
+            assertEquals(ACL.SYSTEM, b.getAction(AuthorizationRecordAction.class).authentication);
+        }
+        
+        {
+            WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "test"+j.jenkins.getItems().size());
+            p.addProperty(new AuthorizeProjectProperty(new AuthorizeProjectStrategyWithOldSignature("test1")));
+            p.setDefinition(new CpsFlowDefinition("node{ step([$class: 'AuthorizationCheckSimpleBuilder']); }", true));
+            WorkflowRun b = p.scheduleBuild2(0).get();
+            j.assertBuildStatusSuccess(b);
+            
+            // Strategies with old signatures don't work for Jobs.
+            assertEquals(ACL.SYSTEM, b.getAction(AuthorizationRecordAction.class).authentication);
+        }
+        
+        {
+            WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "test"+j.jenkins.getItems().size());
+            p.addProperty(new AuthorizeProjectProperty(new SpecificUsersAuthorizationStrategy("test1", true)));
+            User.get("test1");  // create
+            p.setDefinition(new CpsFlowDefinition("node{ step([$class: 'AuthorizationCheckSimpleBuilder']); }", true));
+            WorkflowRun b = p.scheduleBuild2(0).get();
+            j.assertBuildStatusSuccess(b);
+            assertEquals(User.get("test1").impersonate(), b.getAction(AuthorizationRecordAction.class).authentication);
+        }
+    }
+    */
 }

--- a/src/test/java/org/jenkinsci/plugins/authorizeproject/testutil/AuthorizeProjectJenkinsRule.java
+++ b/src/test/java/org/jenkinsci/plugins/authorizeproject/testutil/AuthorizeProjectJenkinsRule.java
@@ -51,7 +51,7 @@ public class AuthorizeProjectJenkinsRule extends JenkinsRule {
         };
     }
     
-    protected void before() throws Throwable {
+    public void before() throws Throwable {
         super.before();
         QueueItemAuthenticatorConfiguration.get().getAuthenticators().add(new ProjectQueueItemAuthenticator());
     }


### PR DESCRIPTION
[JENKINS-26670](https://issues.jenkins-ci.org/browse/JENKINS-26670)

authorize-project is implemented for `AbstractProject`.
This means authorize-project doesn't work for `WorkflowJob` which is a sub class of not `AbstractProject` but `Job`.

This change allows authorize-project to work for `Job` including `WorkflowJob`.