### PR TITLE
[JENKINS-25403] Supports $class

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/authorizeproject/AuthorizeProjectProperty.java
+++ b/src/main/java/org/jenkinsci/plugins/authorizeproject/AuthorizeProjectProperty.java
@@ -179,12 +179,13 @@ public class AuthorizeProjectProperty extends JobProperty<AbstractProject<?,?>> 
             if (formData == null || formData.isNullObject()) {
                 return null;
             }
-            if (!formData.has("stapler-class")) {
-                throw new FormException("No stapler-class is specified", fieldName);
-            }
-            String staplerClazzName = formData.getString("stapler-class");
+            String staplerClazzName = formData.optString("$class", null);
             if (staplerClazzName == null) {
-                throw new FormException("No stapler-class is specified", fieldName);
+                // Fall back on the legacy stapler-class attribute.
+                staplerClazzName = formData.optString("stapler-class", null);
+            }
+            if (staplerClazzName == null) {
+                throw new FormException("No $class nor stapler-class is specified", fieldName);
             }
             try {
                 @SuppressWarnings("unchecked")


### PR DESCRIPTION
[JENKINS-25403](https://issues.jenkins-ci.org/browse/JENKINS-25403)
A trivial fix to support `$class` additional to `stapler-class`.