### PR TITLE
[JENKINS-28298] Administrators can disable specific strategies

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/authorizeproject/AuthorizeProjectProperty.java
+++ b/src/main/java/org/jenkinsci/plugins/authorizeproject/AuthorizeProjectProperty.java
@@ -24,6 +24,9 @@
 
 package org.jenkinsci.plugins.authorizeproject;
 
+import java.util.Collections;
+import java.util.List;
+
 import jenkins.model.Jenkins;
 import jenkins.security.QueueItemAuthenticatorConfiguration;
 
@@ -36,6 +39,7 @@ import org.kohsuke.stapler.StaplerRequest;
 import hudson.DescriptorExtensionList;
 import hudson.Extension;
 import hudson.model.Describable;
+import hudson.model.DescriptorVisibilityFilter;
 import hudson.model.Job;
 import hudson.model.JobProperty;
 import hudson.model.JobPropertyDescriptor;
@@ -129,8 +133,20 @@ public class AuthorizeProjectProperty extends JobProperty<Job<?,?>> {
         /**
          * @return all the registered {@link AuthorizeProjectStrategy}.
          */
+        @Deprecated
         public DescriptorExtensionList<AuthorizeProjectStrategy, Descriptor<AuthorizeProjectStrategy>> getStrategyList() {
             return AuthorizeProjectStrategy.all();
+        }
+        
+        /**
+         * @return enabled {@link AuthorizeProjectStrategy}, empty if authorize-project is not enabled.
+         */
+        public List<Descriptor<AuthorizeProjectStrategy>> getEnabledAuthorizeProjectStrategyDescriptorList() {
+            ProjectQueueItemAuthenticator authenticator = ProjectQueueItemAuthenticator.getConfigured();
+            if (authenticator == null) {
+                return Collections.emptyList();
+            }
+            return DescriptorVisibilityFilter.apply(authenticator, AuthorizeProjectStrategy.all());
         }
         
         /**

--- a/src/main/java/org/jenkinsci/plugins/authorizeproject/AuthorizeProjectStrategyDescriptor.java
+++ b/src/main/java/org/jenkinsci/plugins/authorizeproject/AuthorizeProjectStrategyDescriptor.java
@@ -63,7 +63,7 @@ public abstract class AuthorizeProjectStrategyDescriptor extends Descriptor<Auth
     }
     
     /**
-     * @return return a page to shown in "Configure Global Security" as a child of {@link ProjectQueueItemAuthenticator}.
+     * @return descriptors with configuration views in "Configure Global Security" as a child of {@link ProjectQueueItemAuthenticator}.
      */
     public String getGlobalSecurityConfigPage() {
         for (String cand: getPossibleViewNames("global-security")) {
@@ -106,5 +106,12 @@ public abstract class AuthorizeProjectStrategyDescriptor extends Descriptor<Auth
      * @throws FormException
      */
     public void configureFromGlobalSecurity(StaplerRequest req, JSONObject js) throws FormException {
+    }
+    
+    /**
+     * @return this strategy can be enabled by default.
+     */
+    public boolean isEnabledByDefault() {
+        return true;
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/authorizeproject/strategy/SpecificUsersAuthorizationStrategy.java
+++ b/src/main/java/org/jenkinsci/plugins/authorizeproject/strategy/SpecificUsersAuthorizationStrategy.java
@@ -424,5 +424,15 @@ public class SpecificUsersAuthorizationStrategy extends AuthorizeProjectStrategy
             }
             return FormValidation.ok();
         }
+        
+        /**
+         * {@link SpecificUsersAuthorizationStrategy} should be disabled by default for JENKINS-28298
+         * @return false
+         * @see org.jenkinsci.plugins.authorizeproject.AuthorizeProjectStrategyDescriptor#isEnabledByDefault()
+         */
+        @Override
+        public boolean isEnabledByDefault() {
+            return false;
+        }
     }
 }

--- a/src/main/resources/org/jenkinsci/plugins/authorizeproject/AuthorizeProjectProperty/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/authorizeproject/AuthorizeProjectProperty/config.jelly
@@ -25,6 +25,6 @@ THE SOFTWARE.
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <st:adjunct includes="org.jenkinsci.plugins.authorizeproject.nestedHelp"/>
   <f:optionalBlock name="${descriptor.propertyName}" title="${descriptor.displayName}" checked="${instance != null}">
-    <f:dropdownDescriptorSelector title="${%Authorize Strategy}" field="strategy" descriptors="${descriptor.strategyList}" />
+    <f:dropdownDescriptorSelector title="${%Authorize Strategy}" field="strategy" descriptors="${descriptor.enabledAuthorizeProjectStrategyDescriptorList}" />
   </f:optionalBlock>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/authorizeproject/ProjectQueueItemAuthenticator/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/authorizeproject/ProjectQueueItemAuthenticator/config.jelly
@@ -24,10 +24,15 @@ THE SOFTWARE.
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 <!-- configurations for AuthorizeProjectStrategy -->
-<j:forEach var="d" items="${descriptor.descriptorsForGlobalSecurityConfigPage}">
+<j:forEach var="d" items="${descriptor.availableDescriptorList}">
+<j:scope>
+  <j:set var="checked" value="${instance.isStrategyEnabled(d)}" />
   <j:set var="instance" value="${d}" />
-  <f:rowSet name="${d.jsonSafeClassName}">
-    <st:include page="${d.globalSecurityConfigPage}" from="${d}" />
-  </f:rowSet>
+  <j:set var="descriptor" value="${d}" />
+  <f:optionalBlock name="${d.jsonSafeClassName}" checked="${checked}" help="${d.helpFile}" title="${d.displayName}">
+  <j:set var="instance" value="${d}" />
+    <st:include page="${d.globalSecurityConfigPage}" class="${d.clazz}" optional="true" />
+  </f:optionalBlock>
+</j:scope>
 </j:forEach>
 </j:jelly>

--- a/src/test/java/org/jenkinsci/plugins/authorizeproject/ProjectQueueItemAuthenticatorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/authorizeproject/ProjectQueueItemAuthenticatorTest.java
@@ -83,6 +83,15 @@ public class ProjectQueueItemAuthenticatorTest {
         public Authentication authenticate(Job<?, ?> project, Queue.Item item) {
             return null;
         }
+        
+        @TestExtension
+        public static class DescriptorImpl extends AuthorizeProjectStrategyDescriptor {
+            @Override
+            public String getDisplayName() {
+                return "AuthorizeProjectStrategyWithOldSignature";
+            }
+            
+        }
     }
     
     @Test
@@ -377,6 +386,15 @@ public class ProjectQueueItemAuthenticatorTest {
         @Override
         public Authentication authenticate(AbstractProject<?, ?> project, Queue.Item item) {
             return User.get(name).impersonate();
+        }
+        
+        @TestExtension("testOldSignature")
+        public static class DescriptorImpl extends AuthorizeProjectStrategyDescriptor {
+            @Override
+            public String getDisplayName() {
+                return "AuthorizeProjectStrategyWithOldSignature";
+            }
+            
         }
     }
     

--- a/src/test/java/org/jenkinsci/plugins/authorizeproject/strategy/SpecificUsersAuthorizationStrategyTest.java
+++ b/src/test/java/org/jenkinsci/plugins/authorizeproject/strategy/SpecificUsersAuthorizationStrategyTest.java
@@ -68,7 +68,7 @@ import com.gargoylesoftware.htmlunit.xml.XmlPage;
  */
 public class SpecificUsersAuthorizationStrategyTest {
     @Rule
-    public JenkinsRule j = new AuthorizeProjectJenkinsRule();
+    public JenkinsRule j = new AuthorizeProjectJenkinsRule(SpecificUsersAuthorizationStrategy.class);
     
     private void prepareSecurity() {
         // This allows any users authenticate name == password

--- a/src/test/resources/org/jenkinsci/plugins/authorizeproject/ProjectQueueItemAuthenticatorTest/NullAuthorizeProjectStrategy/config.jelly
+++ b/src/test/resources/org/jenkinsci/plugins/authorizeproject/ProjectQueueItemAuthenticatorTest/NullAuthorizeProjectStrategy/config.jelly
@@ -1,0 +1,27 @@
+<!--
+The MIT License
+
+Copyright (c) 2015 IKEDA Yasuyuki
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+  <!-- dropdownDescriptorSelector causes exception without config.jelly -->
+</j:jelly>


### PR DESCRIPTION
[JENKINS-28298](https://issues.jenkins-ci.org/browse/JENKINS-28298).
Unfortunately, you cab bypass the authentication of "Run as specific user" by CLI or WebAPI on Jenkins > 1.545.
There's nothing authorize-project can do to fix that,
and I filed the issue to Jenkins core ([JENKINS-28440](https://issues.jenkins-ci.org/browse/JENKINS-28440)) and sent a pull request a month ago.

I plan followings for this issue:
* Introduce a feature to disable "Run as specific user" (for users doesn't need that feature).
* Write steps to disable CLI and WebAPI on the Wiki page (I believe they can be disabled by filtering /cli and /*/api)

This is the change to let administrators disable `AuthorizeProjectStrategy`s they don't need.

![enable-disable](https://cloud.githubusercontent.com/assets/3115961/8444136/6e1c6168-1fc8-11e5-9118-f17ccaa0026a.png)
