### PR TITLE
Fix the configuration issue of GlobalQueueItemAuthenticator.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/authorizeproject/AuthorizeProjectUtil.java
+++ b/src/main/java/org/jenkinsci/plugins/authorizeproject/AuthorizeProjectUtil.java
@@ -1,0 +1,84 @@
+/*
+ * The MIT License
+ * 
+ * Copyright (c) 2016 IKEDA Yasuyuki
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.authorizeproject;
+
+import jenkins.model.Jenkins;
+import hudson.model.Describable;
+import hudson.model.Descriptor;
+import hudson.model.Descriptor.FormException;
+import net.sf.json.JSONObject;
+
+import org.kohsuke.stapler.StaplerRequest;
+
+/**
+ *
+ */
+/*package*/ class AuthorizeProjectUtil {
+    /**
+     * Create a new {@link Describable} object from user inputs.
+     * 
+     * @param req
+     * @param formData
+     * @param fieldName
+     * @param clazz
+     * @return
+     * @throws FormException
+     */
+    public static <T extends Describable<?>> T bindJSONWithDescriptor(
+            StaplerRequest req,
+            JSONObject formData,
+            String fieldName,
+            Class<T> clazz
+    ) throws FormException {
+        formData = formData.getJSONObject(fieldName);
+        if (formData == null || formData.isNullObject()) {
+            return null;
+        }
+        String staplerClazzName = formData.optString("$class", null);
+        if (staplerClazzName == null) {
+          // Fall back on the legacy stapler-class attribute.
+          staplerClazzName = formData.optString("stapler-class", null);
+        }
+        if (staplerClazzName == null) {
+            throw new FormException("No $class is specified", fieldName);
+        }
+        try {
+            @SuppressWarnings("unchecked")
+            Class<? extends T> staplerClass = (Class<? extends T>)Jenkins.getInstance().getPluginManager().uberClassLoader.loadClass(staplerClazzName);
+            Descriptor<?> d = Jenkins.getInstance().getDescriptorOrDie(staplerClass);
+            
+            @SuppressWarnings("unchecked")
+            T instance = (T)d.newInstance(req, formData);
+            
+            return instance;
+        } catch(ClassNotFoundException e) {
+            throw new FormException(
+                    String.format("Failed to instantiate %s", staplerClazzName),
+                    e,
+                    fieldName
+            );
+        }
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/authorizeproject/GlobalQueueItemAuthenticator.java
+++ b/src/main/java/org/jenkinsci/plugins/authorizeproject/GlobalQueueItemAuthenticator.java
@@ -5,9 +5,12 @@ import hudson.model.Job;
 import hudson.model.Queue;
 import jenkins.security.QueueItemAuthenticator;
 import jenkins.security.QueueItemAuthenticatorDescriptor;
+import net.sf.json.JSONObject;
+
 import org.acegisecurity.Authentication;
 import org.jenkinsci.plugins.authorizeproject.strategy.AnonymousAuthorizationStrategy;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.StaplerRequest;
 
 /**
  * A global default authenticator to allow changing the default for all projects.
@@ -43,6 +46,29 @@ public class GlobalQueueItemAuthenticator extends QueueItemAuthenticator {
 
         public AuthorizeProjectStrategy getDefaultStrategy() {
             return new AnonymousAuthorizationStrategy();
+        }
+
+        /**
+         * Creates new {@link GlobalQueueItemAuthenticator} from inputs.
+         * This is required to call {@link hudson.model.Descriptor#newInstance(StaplerRequest, JSONObject)}
+         * of {@link AuthorizeProjectProperty}.
+         * 
+         * @param req
+         * @param formData
+         * @return
+         * @throws hudson.model.Descriptor.FormException
+         * @see hudson.model.Descriptor#newInstance(org.kohsuke.stapler.StaplerRequest, net.sf.json.JSONObject)
+         */
+        @Override
+        public GlobalQueueItemAuthenticator newInstance(StaplerRequest req, JSONObject formData)
+                throws FormException
+        {
+            if(formData == null || formData.isNullObject()) {
+                return null;
+            }
+            AuthorizeProjectStrategy strategy = AuthorizeProjectUtil.bindJSONWithDescriptor(req, formData, "strategy", AuthorizeProjectStrategy.class);
+            
+            return new GlobalQueueItemAuthenticator(strategy);
         }
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/authorizeproject/GlobalQueueItemAuthenticatorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/authorizeproject/GlobalQueueItemAuthenticatorTest.java
@@ -111,9 +111,21 @@ public class GlobalQueueItemAuthenticatorTest {
         WebClient wc = j.createWebClient();
         j.submit(wc.goTo("configureSecurity").getFormByName("config"));
         
+        /*
+        // as SpecificUsersAuthorizationStrategy is not annotated with @DataBoundConstoctor,
+        // assertEqualDataBoundBeans is not applicable.
         j.assertEqualDataBoundBeans(
                 auth,
                 QueueItemAuthenticatorConfiguration.get().getAuthenticators().get(GlobalQueueItemAuthenticator.class)
         );
+        */
+        AuthorizeProjectStrategy strategy = QueueItemAuthenticatorConfiguration.get().getAuthenticators().get(GlobalQueueItemAuthenticator.class).getStrategy();
+        assertEquals(SpecificUsersAuthorizationStrategy.class, strategy.getClass());
+        assertEquals(
+                "admin",
+                ((SpecificUsersAuthorizationStrategy)strategy).getUserid()
+        );
+        // Don't care about noNeedReauthentication
+        // (It might be removed for GlobalQueueItemAuthenticator in future)
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/authorizeproject/GlobalQueueItemAuthenticatorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/authorizeproject/GlobalQueueItemAuthenticatorTest.java
@@ -15,6 +15,7 @@ import org.jenkinsci.plugins.authorizeproject.testutil.AuthorizeProjectJenkinsRu
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.JenkinsRule.WebClient;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -82,5 +83,37 @@ public class GlobalQueueItemAuthenticatorTest {
             j.assertBuildStatusSuccess(p.scheduleBuild2(0));
             assertEquals("bob", checker.authentication.getPrincipal());
         }
+    }
+    
+    @Test
+    public void testConfiguration() throws Exception {
+        GlobalQueueItemAuthenticator auth = new GlobalQueueItemAuthenticator(
+                new AnonymousAuthorizationStrategy()
+        );
+        QueueItemAuthenticatorConfiguration.get().getAuthenticators().add(auth);
+        
+        WebClient wc = j.createWebClient();
+        j.submit(wc.goTo("configureSecurity").getFormByName("config"));
+        
+        j.assertEqualDataBoundBeans(
+                auth,
+                QueueItemAuthenticatorConfiguration.get().getAuthenticators().get(GlobalQueueItemAuthenticator.class)
+        );
+    }
+    
+    @Test
+    public void testConfigurationWithDescriptorNewInstance() throws Exception {
+        GlobalQueueItemAuthenticator auth = new GlobalQueueItemAuthenticator(
+                new SpecificUsersAuthorizationStrategy("admin", true)
+        );
+        QueueItemAuthenticatorConfiguration.get().getAuthenticators().add(auth);
+        
+        WebClient wc = j.createWebClient();
+        j.submit(wc.goTo("configureSecurity").getFormByName("config"));
+        
+        j.assertEqualDataBoundBeans(
+                auth,
+                QueueItemAuthenticatorConfiguration.get().getAuthenticators().get(GlobalQueueItemAuthenticator.class)
+        );
     }
 }


### PR DESCRIPTION
[JENKINS-30574](https://issues.jenkins-ci.org/browse/JENKINS-30574)

`GlobalQueueItemAuthenticator` is added in #14.

It causes an exception in the configuration page when configured with `SpecificUsersAuthorizationStrategy`.
It is caused as `SpecificUsersAuthorizationStrategy` is not annotated with `DataBoundConstructor` but expected to be initialized with `Descriptor#newInstance` to perform authentication codes.
I don't annotate it with `DataBoundConstructor` not to allow someone instantiate it in an unexpected way.