### PR TITLE
Strategies can change the configuration behavior for GlobalQueueItemAuthenticator

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/authorizeproject/AuthorizeProjectStrategyDescriptor.java
+++ b/src/main/java/org/jenkinsci/plugins/authorizeproject/AuthorizeProjectStrategyDescriptor.java
@@ -114,4 +114,12 @@ public abstract class AuthorizeProjectStrategyDescriptor extends Descriptor<Auth
     public boolean isEnabledByDefault() {
         return true;
     }
+    
+    /**
+     * @return whether configurable for {@link GlobalQueueItemAuthenticator}
+     * @since 1.1.1
+     */
+    public boolean isApplicableToGlobal() {
+        return true;
+    }
 }

--- a/src/main/java/org/jenkinsci/plugins/authorizeproject/GlobalQueueItemAuthenticator.java
+++ b/src/main/java/org/jenkinsci/plugins/authorizeproject/GlobalQueueItemAuthenticator.java
@@ -1,6 +1,7 @@
 package org.jenkinsci.plugins.authorizeproject;
 
 import hudson.Extension;
+import hudson.model.Descriptor;
 import hudson.model.Job;
 import hudson.model.Queue;
 import jenkins.security.QueueItemAuthenticator;
@@ -8,6 +9,9 @@ import jenkins.security.QueueItemAuthenticatorDescriptor;
 import org.acegisecurity.Authentication;
 import org.jenkinsci.plugins.authorizeproject.strategy.AnonymousAuthorizationStrategy;
 import org.kohsuke.stapler.DataBoundConstructor;
+
+import com.google.common.base.Predicate;
+import com.google.common.collect.Iterables;
 
 /**
  * A global default authenticator to allow changing the default for all projects.
@@ -39,6 +43,23 @@ public class GlobalQueueItemAuthenticator extends QueueItemAuthenticator {
         @Override
         public String getDisplayName() {
             return Messages.GlobalQueueItemAuthenticator_DisplayName();
+        }
+
+        /**
+         * @return Descriptors for {@link AuthorizeProjectStrategy} applicable to {@link GlobalQueueItemAuthenticator}.
+         */
+        public Iterable<Descriptor<AuthorizeProjectStrategy>> getStrategyDescriptors() {
+            return Iterables.filter(
+                    AuthorizeProjectStrategy.all(),
+                    new Predicate<Descriptor<AuthorizeProjectStrategy>>() {
+                        public boolean apply(Descriptor<AuthorizeProjectStrategy> d) {
+                            if (!(d instanceof AuthorizeProjectStrategyDescriptor)) {
+                                return true;
+                            }
+                            return ((AuthorizeProjectStrategyDescriptor)d).isApplicableToGlobal();
+                        }
+                    }
+            );
         }
 
         public AuthorizeProjectStrategy getDefaultStrategy() {

--- a/src/main/java/org/jenkinsci/plugins/authorizeproject/strategy/SpecificUsersAuthorizationStrategy.java
+++ b/src/main/java/org/jenkinsci/plugins/authorizeproject/strategy/SpecificUsersAuthorizationStrategy.java
@@ -257,7 +257,7 @@ public class SpecificUsersAuthorizationStrategy extends AuthorizeProjectStrategy
                 JSONObject formData
         ) throws FormException {
             String userid = formData.getString("userid");
-            boolean noNeedReauthentication = formData.getBoolean("noNeedReauthentication");
+            boolean noNeedReauthentication = formData.optBoolean("noNeedReauthentication", false);
             
             if (StringUtils.isBlank(userid)) {
                 throw new FormException("userid must be specified", "userid");

--- a/src/main/resources/org/jenkinsci/plugins/authorizeproject/AuthorizeProjectProperty/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/authorizeproject/AuthorizeProjectProperty/config.jelly
@@ -23,11 +23,16 @@ THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:hack="/org/jenkinsci/plugins/authorizeproject/form">
+<j:scope>
+  <j:set var="authorizeProjectContext" value="project" />
   <st:adjunct includes="org.jenkinsci.plugins.authorizeproject.nestedHelp"/>
   <f:optionalBlock name="${descriptor.propertyName}" title="${descriptor.displayName}" checked="${instance != null}">
     <!--
         What fun that dropdownDescriptorSelector doesn't add 'it' to the render on demand captured variables
     -->
-    <hack:dropdownDescriptorSelector title="${%Authorize Strategy}" field="strategy" descriptors="${descriptor.enabledAuthorizeProjectStrategyDescriptorList}" />
+    <hack:dropdownDescriptorSelector title="${%Authorize Strategy}" field="strategy" descriptors="${descriptor.enabledAuthorizeProjectStrategyDescriptorList}"
+      capture="authorizeProjectContext"
+    />
   </f:optionalBlock>
+</j:scope>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/authorizeproject/GlobalQueueItemAuthenticator/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/authorizeproject/GlobalQueueItemAuthenticator/config.jelly
@@ -24,5 +24,11 @@ THE SOFTWARE.
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
          xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:hack="/org/jenkinsci/plugins/authorizeproject/form">
-  <hack:dropdownDescriptorSelector field="strategy" default="${descriptor.defaultStrategy}" title="${%Strategy}"/>
+<j:scope>
+  <j:set var="authorizeProjectContext" value="global" />
+  <hack:dropdownDescriptorSelector field="strategy" default="${descriptor.defaultStrategy}" title="${%Strategy}"
+    descriptors="${descriptor.strategyDescriptors}"
+    capture="authorizeProjectContext"
+  />
+</j:scope>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/authorizeproject/form/dropdownDescriptorSelector.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/authorizeproject/form/dropdownDescriptorSelector.jelly
@@ -39,7 +39,7 @@ THE SOFTWARE.
     <st:attribute name="title" use="required">
       Human readable title of this control.
     </st:attribute>
-    <st:attribute name="lazy">
+    <st:attribute name="capture">
       If specified, the additional the variables to be captured. See the @capture of &lt;renderOnDemand> tag.
     </st:attribute>
     <st:attribute name="descriptors">
@@ -66,7 +66,7 @@ THE SOFTWARE.
       <f:dropdownListBlock value="${loop.index}" title="${descriptor.displayName}"
                            selected="${current.descriptor==descriptor || (current==null and descriptor==attrs.default)}"
                            staplerClass="${descriptor.clazz.name}"
-                           lazy="${attrs.lazy?attrs.lazy+',':''}descriptor,it">
+                           lazy="${(attrs.capture != null and attrs.capture != '')?attrs.capture+',':''}descriptor,it">
         <l:ajax>
           <j:set var="instance" value="${current.descriptor==descriptor ? current : null}"/>
           <st:include from="${descriptor}" page="${descriptor.configPage}"/>

--- a/src/main/resources/org/jenkinsci/plugins/authorizeproject/strategy/SpecificUsersAuthorizationStrategy/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/authorizeproject/strategy/SpecificUsersAuthorizationStrategy/config.jelly
@@ -31,6 +31,7 @@ THE SOFTWARE.
   <f:entry title="${%User ID}" field="userid">
     <f:textbox checkPasswordRequestedUrl="${descriptor.calcCheckPasswordRequestedUrl()}" />
   </f:entry>
+  <j:if test="${authorizeProjectContext != 'global'}">
   <f:entry title="${%Password}" field="password">
     <div class="specific-user-authorization-password">
       <f:password />
@@ -43,9 +44,12 @@ THE SOFTWARE.
   <f:entry title="${%No need for re-authentication}" field="noNeedReauthentication">
     <f:checkbox />
   </f:entry>
+  </j:if> <!-- authorizeProjectContext -->
   </table></f:block>
+  <j:if test="${authorizeProjectContext != 'global'}">
   <st:once>
     <st:adjunct includes="org.jenkinsci.plugins.authorizeproject.strategy.SpecificUsersAuthorizationStrategy.checkPasswordRequested" />
     <st:adjunct includes="org.jenkinsci.plugins.authorizeproject.strategy.SpecificUsersAuthorizationStrategy.passwordApitokenSwitch" />
   </st:once>
+  </j:if> <!-- authorizeProjectContext -->
 </j:jelly>


### PR DESCRIPTION
[JENKINS-30574](https://issues.jenkins-ci.org/browse/JENKINS-30574)

* Added `AuthorizeProjectStrategyDescriptor#isApplicableToGlobal` to hide itself from `GlobalQueueItemAuthenticator` (introduced #14).
    * Some strategies can be useless without project configurations.
* Added `authorizeStrategyContext` to jelly, which allows strategies know whether their jelly files are called from `AuthorizeProjectStrategyProperty` or `GlobalQueueItemAuthenticator`.

* `SpecificUserAuthorizationStrategy` from `GlobalQueueItemAuthenticator`

    ![01-global](https://cloud.githubusercontent.com/assets/3115961/13557960/b095c06a-e43b-11e5-8c61-20f2a5e2062a.png)

* `SpecificUserAuthorizationStrategy` from `AuthorizeProjectStrategyProperty` with administrative users.

    ![02-project-admin](https://cloud.githubusercontent.com/assets/3115961/13557967/c7399756-e43b-11e5-9989-e60ec51fd573.png)

* `SpecificUserAuthorizationStrategy` from `AuthorizeProjectStrategyProperty` with non-administrative users.

    ![03-project-nonadmin](https://cloud.githubusercontent.com/assets/3115961/13557968/cbc94276-e43b-11e5-9201-7cf5730423ca.png)

