### PR TITLE
[JENKINS-28298]  Reject unauthenticated configurations via REST / CLI

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,13 @@
       <version>${workflow.version}</version>
       <scope>test</scope>
     </dependency>
+    <!-- Required to avoid cyclic dependency -->
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>script-security</artifactId>
+      <version>1.13</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,11 @@
   
   <dependencies>
     <dependency>
+        <groupId>com.google.code.findbugs</groupId>
+        <artifactId>annotations</artifactId>
+        <version>3.0.1</version>
+    </dependency>
+    <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-job</artifactId>
       <version>${workflow.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -3,8 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.532</version><!-- QueueItemAuthenticator is since 1.520 -->
-    <!--<version>1.580.1</version>--><!-- When you test the integration with workflow -->
+    <version>1.625</version><!-- for JENKINS-28298 -->
   </parent>
 
   <groupId>org.jenkins-ci.plugins</groupId>
@@ -44,8 +43,6 @@
   </properties>
   
   <dependencies>
-    <!-- When you test the integration with workflow -->
-    <!--
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-job</artifactId>
@@ -64,7 +61,6 @@
       <version>${workflow.version}</version>
       <scope>test</scope>
     </dependency>
-    -->
   </dependencies>
   
   <build>

--- a/src/main/java/org/jenkinsci/plugins/authorizeproject/AuthorizeProjectProperty.java
+++ b/src/main/java/org/jenkinsci/plugins/authorizeproject/AuthorizeProjectProperty.java
@@ -40,7 +40,10 @@ import org.kohsuke.stapler.StaplerRequest;
 
 import hudson.DescriptorExtensionList;
 import hudson.Extension;
+import hudson.init.InitMilestone;
+import hudson.init.Initializer;
 import hudson.model.DescriptorVisibilityFilter;
+import hudson.model.Items;
 import hudson.model.Job;
 import hudson.model.JobProperty;
 import hudson.model.JobPropertyDescriptor;
@@ -115,6 +118,11 @@ public class AuthorizeProjectProperty extends JobProperty<Job<?,?>> {
             return null;
         }
         return strategy.authenticate(owner, item);
+    }
+    
+    @Initializer(after=InitMilestone.PLUGINS_STARTED)
+    public static void setStrategyCritical() {
+        Items.XSTREAM2.addCriticalField(AuthorizeProjectProperty.class, "strategy");
     }
     
     /**

--- a/src/main/java/org/jenkinsci/plugins/authorizeproject/AuthorizeProjectStrategy.java
+++ b/src/main/java/org/jenkinsci/plugins/authorizeproject/AuthorizeProjectStrategy.java
@@ -49,7 +49,7 @@ public abstract class AuthorizeProjectStrategy extends AbstractDescribableImpl<A
      * @return all the registered {@link AuthorizeProjectStrategy}.
      */
     public static DescriptorExtensionList<AuthorizeProjectStrategy, Descriptor<AuthorizeProjectStrategy>> all() {
-        return Jenkins.getInstance().getDescriptorList(AuthorizeProjectStrategy.class);
+        return Jenkins.getActiveInstance().getDescriptorList(AuthorizeProjectStrategy.class);
     }
     
     /**
@@ -71,7 +71,7 @@ public abstract class AuthorizeProjectStrategy extends AbstractDescribableImpl<A
         }
         
         if (!(project instanceof AbstractProject)) {
-            Descriptor<?> d = Jenkins.getInstance().getDescriptor(getClass());
+            Descriptor<?> d = Jenkins.getActiveInstance().getDescriptor(getClass());
             LOGGER.log(
                     Level.WARNING,
                     "This authorization strategy ({0}) is designed for authorize-project < 1.1.0 and not applicable for non-AbstractProjects (like WorkflowJob). ignored.",

--- a/src/main/java/org/jenkinsci/plugins/authorizeproject/AuthorizeProjectStrategyDescriptor.java
+++ b/src/main/java/org/jenkinsci/plugins/authorizeproject/AuthorizeProjectStrategyDescriptor.java
@@ -58,7 +58,7 @@ public abstract class AuthorizeProjectStrategyDescriptor extends Descriptor<Auth
 
     @Override
     protected final XmlFile getConfigFile() {
-        return new XmlFile(new File(Jenkins.getInstance().getRootDir(),
+        return new XmlFile(new File(Jenkins.getActiveInstance().getRootDir(),
                 Constants.CONFIG_FOLDER+"/"+getId()+".xml"));
     }
     

--- a/src/main/java/org/jenkinsci/plugins/authorizeproject/AuthorizeProjectUtil.java
+++ b/src/main/java/org/jenkinsci/plugins/authorizeproject/AuthorizeProjectUtil.java
@@ -68,8 +68,8 @@ public class AuthorizeProjectUtil {
         }
         try {
             @SuppressWarnings("unchecked")
-            Class<? extends T> staplerClass = (Class<? extends T>)Jenkins.getInstance().getPluginManager().uberClassLoader.loadClass(staplerClazzName);
-            Descriptor<?> d = Jenkins.getInstance().getDescriptorOrDie(staplerClass);
+            Class<? extends T> staplerClass = (Class<? extends T>)Jenkins.getActiveInstance().getPluginManager().uberClassLoader.loadClass(staplerClazzName);
+            Descriptor<?> d = Jenkins.getActiveInstance().getDescriptorOrDie(staplerClass);
             
             @SuppressWarnings("unchecked")
             T instance = (T)d.newInstance(req, formData);

--- a/src/main/java/org/jenkinsci/plugins/authorizeproject/AuthorizeProjectUtil.java
+++ b/src/main/java/org/jenkinsci/plugins/authorizeproject/AuthorizeProjectUtil.java
@@ -24,6 +24,8 @@
 
 package org.jenkinsci.plugins.authorizeproject;
 
+import javax.annotation.CheckForNull;
+
 import jenkins.model.Jenkins;
 import hudson.model.Describable;
 import hudson.model.Descriptor;
@@ -82,8 +84,13 @@ public class AuthorizeProjectUtil {
         }
     }
     
-    public static boolean userIdEquals(String a, String b) {
-        // TODO use Jenkins.getInstance().getSecurityRealm().getUserIdStrategy().equals() once Jenkins 1.566+
-        return a.equals(b);
+    public static boolean userIdEquals(@CheckForNull String a, @CheckForNull String b) {
+        if (a == null) {
+            return b == null;
+        }
+        if (b == null) {
+            return false;
+        }
+        return Jenkins.getActiveInstance().getSecurityRealm().getUserIdStrategy().equals(a, b);
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/authorizeproject/strategy/SpecificUsersAuthorizationStrategy.java
+++ b/src/main/java/org/jenkinsci/plugins/authorizeproject/strategy/SpecificUsersAuthorizationStrategy.java
@@ -109,10 +109,6 @@ public class SpecificUsersAuthorizationStrategy extends AuthorizeProjectStrategy
             return Jenkins.ANONYMOUS;
         }
         Authentication a = u.impersonate();
-        if (a == null) {
-            // fallback to anonymous
-            return Jenkins.ANONYMOUS;
-        }
         return a;
     }
     
@@ -132,7 +128,7 @@ public class SpecificUsersAuthorizationStrategy extends AuthorizeProjectStrategy
             return false;
         }
         
-        if (Jenkins.getInstance().hasPermission(Jenkins.ADMINISTER)) {
+        if (Jenkins.getActiveInstance().hasPermission(Jenkins.ADMINISTER)) {
             // Administrator can specify any user.
             return false;
         }
@@ -285,7 +281,7 @@ public class SpecificUsersAuthorizationStrategy extends AuthorizeProjectStrategy
                 String password
         ) {
             try {
-                Jenkins.getInstance().getSecurityRealm().getSecurityComponents().manager.authenticate(
+                Jenkins.getActiveInstance().getSecurityRealm().getSecurityComponents().manager.authenticate(
                         new UsernamePasswordAuthenticationToken(strategy.getUserid(), password)
                 );
             } catch (Exception e) { // handles any exception including NPE.
@@ -471,7 +467,7 @@ public class SpecificUsersAuthorizationStrategy extends AuthorizeProjectStrategy
         }
         
         public boolean isUseApitoken() {
-            return !(Jenkins.getInstance().getSecurityRealm() instanceof AbstractPasswordBasedSecurityRealm);
+            return !(Jenkins.getActiveInstance().getSecurityRealm() instanceof AbstractPasswordBasedSecurityRealm);
         }
         
         /**

--- a/src/main/java/org/jenkinsci/plugins/authorizeproject/strategy/SpecificUsersAuthorizationStrategy.java
+++ b/src/main/java/org/jenkinsci/plugins/authorizeproject/strategy/SpecificUsersAuthorizationStrategy.java
@@ -138,7 +138,7 @@ public class SpecificUsersAuthorizationStrategy extends AuthorizeProjectStrategy
         }
         
         User u = User.current();
-        if (u != null && u.getId() != null && AuthorizeProjectUtil.userIdEquals(u.getId(), newStrategy.getUserid())) {
+        if (u != null && AuthorizeProjectUtil.userIdEquals(u.getId(), newStrategy.getUserid())) {
             // Any user can specify oneself.
             return false;
         }
@@ -150,7 +150,6 @@ public class SpecificUsersAuthorizationStrategy extends AuthorizeProjectStrategy
 
         if (
                 currentStrategy.isNoNeedReauthentication()
-                && currentStrategy.getUserid() != null
                 && AuthorizeProjectUtil.userIdEquals(currentStrategy.getUserid(), newStrategy.getUserid())
         ) {
             // the specified user is not changed, 
@@ -261,7 +260,7 @@ public class SpecificUsersAuthorizationStrategy extends AuthorizeProjectStrategy
                 throw new FormException("userid must be specified", "userid");
             }
             for (Authentication a: BUILTIN_USERS) {
-                if (AuthorizeProjectUtil.userIdEquals(userid, a.getPrincipal().toString())) {
+                if (AuthorizeProjectUtil.userIdEquals(userid, (a.getPrincipal() != null)?a.getPrincipal().toString():null)) {
                     throw new FormException(Messages.SpecificUsersAuthorizationStrategy_userid_builtin(), "userid");
                 }
             }

--- a/src/main/java/org/jenkinsci/plugins/authorizeproject/strategy/SystemAuthorizationStrategy.java
+++ b/src/main/java/org/jenkinsci/plugins/authorizeproject/strategy/SystemAuthorizationStrategy.java
@@ -43,6 +43,8 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 /**
  * Run builds as {@link ACL#SYSTEM}. Using this strategy becomes important when
  * {@link org.jenkinsci.plugins.authorizeproject.GlobalQueueItemAuthenticator}
@@ -126,6 +128,7 @@ public class SystemAuthorizationStrategy extends AuthorizeProjectStrategy {
      * @param obj the object to test equality with.
      * @return {@code true} if and only if this is a equivalent {@link SystemAuthorizationStrategy} instance.
      */
+    @SuppressFBWarnings(value="EQ_GETCLASS_AND_CLASS_CONSTANT", justification="Should be the same class")
     @Override
     public final boolean equals(Object obj) {
         return obj != null && SystemAuthorizationStrategy.class == obj.getClass();

--- a/src/test/java/org/jenkinsci/plugins/authorizeproject/ProjectQueueItemAuthenticatorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/authorizeproject/ProjectQueueItemAuthenticatorTest.java
@@ -61,8 +61,6 @@ import com.gargoylesoftware.htmlunit.html.HtmlForm;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
 import com.gargoylesoftware.htmlunit.html.HtmlTextInput;
 
-/*
-// classes for workflowTest
 import java.io.IOException;
 import jenkins.tasks.SimpleBuildStep;
 import hudson.FilePath;
@@ -76,8 +74,6 @@ import org.jenkinsci.plugins.authorizeproject.strategy.SpecificUsersAuthorizatio
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
-import org.kohsuke.stapler.DataBoundConstructor;
-*/
 
 /**
  *
@@ -511,10 +507,6 @@ public class ProjectQueueItemAuthenticatorTest {
         assertEquals("test1", checker.authentication.getName());
     }
     
-    /*
-    // A test for workflow plugin (which extends Job, not AbstractProject).
-    // This is disabled as workflow requires Jenkins >= 1.580.1
-    // but authorize-project targets Jenkins >= 1.532.
     public static class AuthorizationRecordAction extends InvisibleAction {
         public final Authentication authentication;
         
@@ -580,5 +572,4 @@ public class ProjectQueueItemAuthenticatorTest {
             assertEquals(User.get("test1").impersonate(), b.getAction(AuthorizationRecordAction.class).authentication);
         }
     }
-    */
 }

--- a/src/test/java/org/jenkinsci/plugins/authorizeproject/ProjectQueueItemAuthenticatorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/authorizeproject/ProjectQueueItemAuthenticatorTest.java
@@ -80,7 +80,7 @@ import org.jenkinsci.plugins.workflow.job.WorkflowRun;
  */
 public class ProjectQueueItemAuthenticatorTest {
     @Rule
-    public JenkinsRule j = new AuthorizeProjectJenkinsRule();
+    public JenkinsRule j = new AuthorizeProjectJenkinsRule(SpecificUsersAuthorizationStrategy.class);
     
     public static class NullAuthorizeProjectStrategy extends AuthorizeProjectStrategy {
         @DataBoundConstructor
@@ -485,7 +485,7 @@ public class ProjectQueueItemAuthenticatorTest {
             return User.get(name).impersonate();
         }
         
-        @TestExtension("testOldSignature")
+        @TestExtension
         public static class DescriptorImpl extends AuthorizeProjectStrategyDescriptor {
             @Override
             public String getDisplayName() {


### PR DESCRIPTION
[JENKINS-28298](https://issues.jenkins-ci.org/browse/JENKINS-28298)

See also https://wiki.jenkins-ci.org/display/JENKINS/JENKINS-28298

When using authorize-project <= 1.1.0 with Jenkins >= 1.545, 
users can inject unauthenticated `SpecificUserAuthorizationStrategy` and `SystemAuthorizationStrategy` (`SystemAuthorizationStrategy` is not released yet).

Followings are required for the fundamental resolution:
* Call `XStream2#addCriticalField`
    * Required Jenkins >=  1.551.
* Use Jenkins >= 1.625

Jenkins 1.532 - 1.544 is not affected by this issue, and I know I can support those versions by using Java reflections to call `XStream2#addCriticalField`.

But I decided to change the target version to 1.625 as:

* It results unnecessarily complicated codes to use Java reflections.
* Those who use Jenkins 1.545 - 1.624 will be still affected this issue. 
