### PR TITLE
[FIXED JENKINS-33897] The adjunct passwordApiTokenSwitch is incorrectly referenced on the plugin

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/authorizeproject/strategy/SpecificUsersAuthorizationStrategy/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/authorizeproject/strategy/SpecificUsersAuthorizationStrategy/config.jelly
@@ -49,7 +49,7 @@ THE SOFTWARE.
   <j:if test="${authorizeProjectContext != 'global'}">
   <st:once>
     <st:adjunct includes="org.jenkinsci.plugins.authorizeproject.strategy.SpecificUsersAuthorizationStrategy.checkPasswordRequested" />
-    <st:adjunct includes="org.jenkinsci.plugins.authorizeproject.strategy.SpecificUsersAuthorizationStrategy.passwordApitokenSwitch" />
+    <st:adjunct includes="org.jenkinsci.plugins.authorizeproject.strategy.SpecificUsersAuthorizationStrategy.passwordApiTokenSwitch" />
   </st:once>
   </j:if> <!-- authorizeProjectContext -->
 </j:jelly>


### PR DESCRIPTION
The adjunct `passwordApiTokenSwitch` is incorrectly referenced on the plugin.

The stacktrace comes from:
https://github.com/stapler/stapler/blob/master/jelly/src/main/java/org/kohsuke/stapler/framework/adjunct/AdjunctsInPage.java#L166

In the plugin the adjunct is referenced here:
https://github.com/jenkinsci/authorize-project-plugin/blob/c2aaa513780dd7e695f8234bf86ef06cba2485f4/src/main/resources/org/jenkinsci/plugins/authorizeproject/strategy/SpecificUsersAuthorizationStrategy/config.jelly#L52

But the adjunct is with capital T:
https://github.com/jenkinsci/authorize-project-plugin/blob/c2aaa513780dd7e695f8234bf86ef06cba2485f4/src/main/resources/org/jenkinsci/plugins/authorizeproject/strategy/SpecificUsersAuthorizationStrategy/passwordApiTokenSwitch.js

```
<st:adjunct includes="org.jenkinsci.plugins.authorizeproject.strategy.SpecificUsersAuthorizationStrategy.passwordApitokenSwitch" /> <<<< lowercase
src/main/resources/org/jenkinsci/plugins/authorizeproject/strategy/SpecificUsersAuthorizationStrategy/passwordApiTokenSwitch.js <<< uppercase
```

This produces the following stacktrace:

```
2016-03-30 08:46:08.163+0200 [id=86]    WARNING o.k.s.f.adjunct.AdjunctsInPage#findNeeded: No such adjunct found: org.jenkinsci.plugins.authorizeproject.strategy.SpecificUsersAuthorizationStrategy.passwordApitokenSwitchorg.kohsuke.stapler.framework.adjunct.NoSuchAdjunctException: Neither org.jenkinsci.plugins.authorizeproject.strategy.SpecificUsersAuthorizationStrategy.passwordApitokenSwitch.css, .js, .html, nor .jelly were found
    at org.kohsuke.stapler.framework.adjunct.Adjunct.<init>(Adjunct.java:125)
    at org.kohsuke.stapler.framework.adjunct.AdjunctManager.get(AdjunctManager.java:147)
    at org.kohsuke.stapler.framework.adjunct.AdjunctsInPage.findNeeded(AdjunctsInPage.java:161)
    at org.kohsuke.stapler.framework.adjunct.AdjunctsInPage.generate(AdjunctsInPage.java:113)
    at org.kohsuke.stapler.jelly.AdjunctTag.doTag(AdjunctTag.java:83)
    at org.apache.commons.jelly.impl.TagScript.run(TagScript.java:269)
    at org.apache.commons.jelly.impl.ScriptBlock.run(ScriptBlock.java:95)
    at org.kohsuke.stapler.jelly.StaplerTagLibrary$3.run(StaplerTagLibrary.java:104)
    at org.apache.commons.jelly.tags.core.CoreTagLibrary$1.run(CoreTagLibrary.java:98)
    at org.apache.commons.jelly.impl.ScriptBlock.run(ScriptBlock.java:95)
    at org.apache.commons.jelly.tags.core.CoreTagLibrary$2.run(CoreTagLibrary.java
```

https://issues.jenkins-ci.org/browse/JENKINS-33897

@reviewbybees @ikedam @daniel-beck 