### PR TITLE
[FIXED JENKINS-34279] Handle UsernameNotFoundException.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/authorizeproject/strategy/SpecificUsersAuthorizationStrategy.java
+++ b/src/main/java/org/jenkinsci/plugins/authorizeproject/strategy/SpecificUsersAuthorizationStrategy.java
@@ -44,6 +44,7 @@ import net.sf.json.JSONObject;
 
 import org.acegisecurity.Authentication;
 import org.acegisecurity.providers.UsernamePasswordAuthenticationToken;
+import org.acegisecurity.userdetails.UsernameNotFoundException;
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.authorizeproject.AuthorizeProjectStrategy;
 import org.jenkinsci.plugins.authorizeproject.AuthorizeProjectStrategyDescriptor;
@@ -108,8 +109,13 @@ public class SpecificUsersAuthorizationStrategy extends AuthorizeProjectStrategy
             // fallback to anonymous
             return Jenkins.ANONYMOUS;
         }
-        Authentication a = u.impersonate();
-        return a;
+        try {
+            Authentication a = u.impersonate();
+            return a;
+        } catch (UsernameNotFoundException e) {
+            LOGGER.log(Level.WARNING, String.format("Invalid User %s. Falls back to anonymous.", getUserid()), e);
+            return Jenkins.ANONYMOUS;
+        }
     }
     
     /**

--- a/src/main/java/org/jenkinsci/plugins/authorizeproject/strategy/TriggeringUsersAuthorizationStrategy.java
+++ b/src/main/java/org/jenkinsci/plugins/authorizeproject/strategy/TriggeringUsersAuthorizationStrategy.java
@@ -34,8 +34,11 @@ import hudson.model.Queue;
 import hudson.model.Run;
 import hudson.model.User;
 import java.util.Collections;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import org.acegisecurity.Authentication;
+import org.acegisecurity.userdetails.UsernameNotFoundException;
 import org.jenkinsci.plugins.authorizeproject.AuthorizeProjectStrategy;
 import org.jenkinsci.plugins.authorizeproject.AuthorizeProjectStrategyDescriptor;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -44,6 +47,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
  * Run builds as a user who triggered the build.
  */
 public class TriggeringUsersAuthorizationStrategy extends AuthorizeProjectStrategy {
+    private static final Logger LOGGER = Logger.getLogger(TriggeringUsersAuthorizationStrategy.class.getName());
     /**
      * 
      */
@@ -65,7 +69,12 @@ public class TriggeringUsersAuthorizationStrategy extends AuthorizeProjectStrate
             if (u == null) {
                 return Jenkins.ANONYMOUS;
             }
-            return u.impersonate();
+            try {
+                return u.impersonate();
+            } catch (UsernameNotFoundException e) {
+                LOGGER.log(Level.WARNING, String.format("Invalid User %s. Falls back to anonymous.", cause.getUserId()), e);
+                return Jenkins.ANONYMOUS;
+            }
         }
         return null;
     }

--- a/src/test/java/org/jenkinsci/plugins/authorizeproject/testutil/SecurityRealmWithUserFilter.java
+++ b/src/test/java/org/jenkinsci/plugins/authorizeproject/testutil/SecurityRealmWithUserFilter.java
@@ -1,0 +1,73 @@
+/*
+ * The MIT License
+ * 
+ * Copyright (c) 2016 IKEDA Yasuyuki
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.authorizeproject.testutil;
+
+import java.util.List;
+
+import hudson.security.SecurityRealm;
+
+import org.acegisecurity.userdetails.UserDetails;
+import org.acegisecurity.userdetails.UserDetailsService;
+import org.acegisecurity.userdetails.UsernameNotFoundException;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.springframework.dao.DataAccessException;
+
+/**
+ * Wraps other {@link SecurityRealm},
+ * and throws {@link UsernameNotFoundException} for unknown users.
+ * 
+ * Expected to be used with {@link JenkinsRule#createDummySecurityRealm()}
+ */
+public class SecurityRealmWithUserFilter extends SecurityRealm {
+    private final SecurityRealm baseSecurityRealm;
+    private final List<String> validUserList;
+    
+    public SecurityRealmWithUserFilter(SecurityRealm baseSecurityRealm, List<String> validUserList) {
+        this.baseSecurityRealm = baseSecurityRealm;
+        this.validUserList = validUserList;
+    }
+    
+    @Override
+    public SecurityComponents createSecurityComponents() {
+        final SecurityComponents baseComponent = baseSecurityRealm.createSecurityComponents();
+        return new SecurityComponents(
+                baseComponent.manager,
+                new UserDetailsService() {
+                    @Override
+                    public UserDetails loadUserByUsername(String username)
+                            throws UsernameNotFoundException, DataAccessException
+                    {
+                        if (!validUserList.contains(username)) {
+                            throw new UsernameNotFoundException(
+                                    String.format("%s is not listed as valid username.", username)
+                            );
+                        }
+                        return baseComponent.userDetails.loadUserByUsername(username);
+                    }
+                },
+                baseComponent.rememberMe
+        );
+    }
+}


### PR DESCRIPTION
[JENKINS-34279](https://issues.jenkins-ci.org/browse/JENKINS-34279)

`SecurityRealm`s may fail to resolve users and throws `UsernameNotFoundException` for those cases.