### PR TITLE
JENKINS-55052: Hack to work around issue with cause propagation

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/authorizeproject/strategy/Messages.properties
+++ b/src/main/resources/org/jenkinsci/plugins/authorizeproject/strategy/Messages.properties
@@ -21,6 +21,7 @@
 # THE SOFTWARE.
 
 TriggeringUsersAuthorizationStrategy.DisplayName=Run as User who Triggered Build
+TriggeringUsersAuthorizationStrategy.waitingQueueItemAuthorizationWorkaround.usage=This feature is a security risk; use with caution. This works around a defect in the handling propagation of user IDs for Queue.WaitingItem. This opens a security hole where by the incorrect USER private credentials may be exposed in certain cases. Use this only with great care.
 SpecificUsersAuthorizationStrategy.DisplayName=Run as Specific User
 SpecificUsersAuthorizationStrategy.userid.required=Required
 SpecificUsersAuthorizationStrategy.userid.builtin=You cannot specify a built-in user with this strategy

--- a/src/main/resources/org/jenkinsci/plugins/authorizeproject/strategy/TriggeringUsersAuthorizationStrategy/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/authorizeproject/strategy/TriggeringUsersAuthorizationStrategy/config.jelly
@@ -24,4 +24,7 @@ THE SOFTWARE.
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <!-- dropdownDescriptorSelector causes exception without config.jelly -->
+  <f:entry title="${%Allow waiting queue item authorization workaround}" field="waitingQueueItemAuthorizationWorkaround">
+    <f:checkbox />
+  </f:entry>
 </j:jelly>


### PR DESCRIPTION
This is a hack to workaround an issue with `UserIdCause` propagation detailed in defect: https://issues.jenkins-ci.org/browse/JENKINS-55052

---

I am opening the pull request to get attention to the issue. The unit testing for the workaround is lacking outside of what exists today in the plugin.

I am looking for suggestions / pointers / examples as to how I should provide sufficient testing for the patch provided and / or where I should look to potentially fix the underlying issue upstream.