### PR TITLE
Remove outdated Javadoc on SpecificUsersAuthorizationStrategy

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/authorizeproject/strategy/SpecificUsersAuthorizationStrategy.java
+++ b/src/main/java/org/jenkinsci/plugins/authorizeproject/strategy/SpecificUsersAuthorizationStrategy.java
@@ -110,11 +110,6 @@ public class SpecificUsersAuthorizationStrategy extends AuthorizeProjectStrategy
         }
     }
 
-    /**
-     * No {@link DataBoundConstructor} for requiring to pass the authentication.
-     *
-     * authentication is performed in {@link DescriptorImpl#newInstance(StaplerRequest, JSONObject)}
-     */
     @DataBoundConstructor
     public SpecificUsersAuthorizationStrategy(String userid, boolean useApitoken,
                                               String apitoken, String password) throws AccessDeniedException {


### PR DESCRIPTION
Since commit 4ebd13f03e the comment about the @DataBoundConstructor is invalid.
Since commit 5e13d24962 the comment about the authentication is invalid.