### PR TITLE
[JENKINS-64341] Removed table, tr and td tags for new Jenkins versions

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/authorizeproject/AuthorizeProjectProperty/AuthorizationAction/index.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/authorizeproject/AuthorizeProjectProperty/AuthorizationAction/index.jelly
@@ -24,7 +24,38 @@
  ~ THE SOFTWARE.
  -->
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout"
-         xmlns:f="/lib/form" xmlns:t="/lib/hudson">
+         xmlns:f="/lib/form" xmlns:t="/lib/hudson" xmlns:d="jelly:define"
+         xmlns:local="local">
+  <d:taglib uri="local">
+    <d:tag name="blockWrapperTr">
+      <j:choose>
+        <j:when test="${divBasedFormLayout}">
+          <div>
+            <d:invokeBody/>
+          </div>
+        </j:when>
+        <j:otherwise>
+          <tr>
+            <d:invokeBody/>
+          </tr>
+        </j:otherwise>
+      </j:choose>
+    </d:tag>
+    <d:tag name="blockWrapperTd">
+      <j:choose>
+        <j:when test="${divBasedFormLayout}">
+          <div>
+            <d:invokeBody/>
+          </div>
+        </j:when>
+        <j:otherwise>
+          <td>
+            <d:invokeBody/>
+          </td>
+        </j:otherwise>
+      </j:choose>
+    </d:tag>
+  </d:taglib>
   <l:layout title="${it.displayName}" norefresh="true" permission="${it.job.CONFIGURE}">
     <st:include it="${it.job}" page="sidepanel" optional="true"/>
     <l:main-panel>
@@ -36,11 +67,11 @@
       <p/>
       <div class="behavior-loading">${%LOADING}</div>
       <f:form action="authorize" method="post" name="config">
-        <tr>
-          <td>
+        <local:blockWrapperTr>
+          <local:blockWrapperTd>
             <input type="hidden" name="stapler-class-bag" value="true"/>
-          </td>
-        </tr>
+          </local:blockWrapperTd>
+        </local:blockWrapperTr>
         <j:set var="instance" value="${it.property}"/>
         <j:set var="descriptor" value="${it.propertyDescriptor}"/>
         <f:optionalBlock name="${descriptor.jsonSafeClassName}" help="${descriptor.helpFile}"

--- a/src/main/resources/org/jenkinsci/plugins/authorizeproject/ProjectQueueItemAuthenticator/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/authorizeproject/ProjectQueueItemAuthenticator/config.jelly
@@ -22,10 +22,26 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:local="local">
+  <d:taglib uri="local">
+    <d:tag name="blockWrapperTable" >
+      <j:choose>
+        <j:when test="${divBasedFormLayout}">
+          <div style="width:100%">
+            <d:invokeBody/>
+          </div>
+        </j:when>
+        <j:otherwise>
+          <table width="100%">
+            <d:invokeBody/>
+          </table>
+        </j:otherwise>
+      </j:choose>
+    </d:tag>
+  </d:taglib>
 <!-- configurations for AuthorizeProjectStrategy -->
   <f:entry title="${%Strategies}">
-    <table width="100%">
+    <local:blockWrapperTable>
       <j:forEach var="d" items="${descriptor.availableDescriptorList}">
         <j:scope>
           <j:set var="checked" value="${instance==null?d.enabledByDefault: instance.isStrategyEnabled(d)}" />
@@ -37,6 +53,6 @@ THE SOFTWARE.
           </f:optionalBlock>
         </j:scope>
       </j:forEach>
-    </table>
+    </local:blockWrapperTable>
   </f:entry>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/authorizeproject/strategy/SpecificUsersAuthorizationStrategy/checkPasswordRequested.js
+++ b/src/main/resources/org/jenkinsci/plugins/authorizeproject/strategy/SpecificUsersAuthorizationStrategy/checkPasswordRequested.js
@@ -46,8 +46,13 @@ Behaviour.specify(".specific-user-authorization", "checkPasswordRequired", 0, fu
   var useridField = findFormItem(e, "userid", findChild(e));
   var passwordField = findFormItem(e, "password", findChild(e));
   var passwordFieldBlock = findAncestor(passwordField, "TR");
+  if (passwordFieldBlock == null) {
+      passwordFieldBlock = findAncestorClass(passwordField, "tr");
+    }
+
   var passwordCheckBlock = findFollowingTR(passwordField, "validation-error-area");
   var passwordHelpBlock = findFollowingTR(passwordField, "help-area");
+
   var passwordBlockList = [
     passwordFieldBlock,
     passwordCheckBlock,

--- a/src/main/resources/org/jenkinsci/plugins/authorizeproject/strategy/SpecificUsersAuthorizationStrategy/checkPasswordRequested.js
+++ b/src/main/resources/org/jenkinsci/plugins/authorizeproject/strategy/SpecificUsersAuthorizationStrategy/checkPasswordRequested.js
@@ -46,6 +46,13 @@ Behaviour.specify(".specific-user-authorization", "checkPasswordRequired", 0, fu
   var useridField = findFormItem(e, "userid", findChild(e));
   var passwordField = findFormItem(e, "password", findChild(e));
   var passwordFieldBlock = findAncestor(passwordField, "TR");
+  /*
+    [JENKINS-64341] - In Jenkins version greater than 2.263.4
+    the table tags for fields (in forms) were replaced by div tags.
+    Since the changes were applied the 'findAncestor(passwordField, "TR")'
+    method returns null. It is necessary to use the method
+    'findAncestorClass(passwordField, "tr")' instead of.
+  */
   if (passwordFieldBlock == null) {
       passwordFieldBlock = findAncestorClass(passwordField, "tr");
     }

--- a/src/main/resources/org/jenkinsci/plugins/authorizeproject/strategy/SpecificUsersAuthorizationStrategy/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/authorizeproject/strategy/SpecificUsersAuthorizationStrategy/config.jelly
@@ -22,10 +22,26 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-<f:block>
-  <table style="width:100%" class="specific-user-authorization">
-  <!-- 
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:local="local">
+  <d:taglib uri="local">
+    <d:tag name="blockWrapperTable" >
+      <j:choose>
+        <j:when test="${divBasedFormLayout}">
+          <div style="width:100%" class="specific-user-authorization">
+            <d:invokeBody/>
+          </div>
+        </j:when>
+        <j:otherwise>
+          <table style="width:100%" class="specific-user-authorization">
+            <d:invokeBody/>
+          </table>
+        </j:otherwise>
+      </j:choose>
+    </d:tag>
+  </d:taglib>
+  <f:block>
+  <local:blockWrapperTable>
+  <!--
     hetero-radio makes entries visible even they are hidden.
     So nest it not to handled by hetero-radio.
   -->
@@ -46,7 +62,7 @@ THE SOFTWARE.
     <f:checkbox />
   </f:entry>
   </j:if> <!-- authorizeProjectContext -->
-  </table>
+  </local:blockWrapperTable>
   <j:if test="${authorizeProjectContext != 'global'}">
   <st:once>
     <st:adjunct includes="org.jenkinsci.plugins.authorizeproject.strategy.SpecificUsersAuthorizationStrategy.checkPasswordRequested" />


### PR DESCRIPTION
[JENKINS-64341]

I checked the master version running from a Jenkins 2.279 and I found some UI design errors using div instead of tables. So, I removed all table/tbody/tr/td/th tag matches for new Jenkins versions where we have the variable divBasedFormLayout.

Additionally, I needed to modify the checkPasswordRequested.js file to hide the password field using div.