### PR TITLE
[JENKINS-56774] Add JCasC support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,16 @@
       <artifactId>workflow-cps</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>io.jenkins</groupId>
+      <artifactId>configuration-as-code</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.jenkins.configuration-as-code</groupId>
+      <artifactId>test-harness</artifactId>
+      <scope>test</scope>
+    </dependency>
     <!-- Required to avoid cyclic dependency -->
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/java/org/jenkinsci/plugins/authorizeproject/strategy/SpecificUsersAuthorizationStrategy.java
+++ b/src/main/java/org/jenkinsci/plugins/authorizeproject/strategy/SpecificUsersAuthorizationStrategy.java
@@ -50,6 +50,7 @@ import org.jenkinsci.plugins.authorizeproject.AuthorizeProjectStrategy;
 import org.jenkinsci.plugins.authorizeproject.AuthorizeProjectStrategyDescriptor;
 import org.jenkinsci.plugins.authorizeproject.AuthorizeProjectUtil;
 import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.DoNotUse;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
@@ -63,6 +64,20 @@ public class SpecificUsersAuthorizationStrategy extends AuthorizeProjectStrategy
     private static Logger LOGGER = Logger.getLogger(SpecificUsersAuthorizationStrategy.class.getName());
     private final String userid;
     
+    /*
+     * The fields "useApitoken", "apitoken", and "password" are part of the @DataBoundConstructor annotated constructor,
+     * but they are only required for validation during form submission. They are put here and marked restricted and
+     * transient to make Configuration as Code ignore them when exporting the configuration.
+     */
+    @Restricted(DoNotUse.class)
+    private transient Boolean useApitoken;
+
+    @Restricted(DoNotUse.class)
+    private transient String apitoken;
+
+    @Restricted(DoNotUse.class)
+    private transient String password;
+
     private final static Authentication[] BUILTIN_USERS = {
             ACL.SYSTEM,
             Jenkins.ANONYMOUS,

--- a/src/test/java/org/jenkinsci/plugins/authorizeproject/ConfigurationAsCodeTest.java
+++ b/src/test/java/org/jenkinsci/plugins/authorizeproject/ConfigurationAsCodeTest.java
@@ -1,0 +1,135 @@
+package org.jenkinsci.plugins.authorizeproject;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertThat;
+
+import hudson.util.DescribableList;
+import io.jenkins.plugins.casc.ConfigurationContext;
+import io.jenkins.plugins.casc.ConfiguratorRegistry;
+import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
+import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
+import io.jenkins.plugins.casc.misc.Util;
+import io.jenkins.plugins.casc.model.CNode;
+import java.util.Arrays;
+import java.util.HashSet;
+import jenkins.security.QueueItemAuthenticator;
+import jenkins.security.QueueItemAuthenticatorConfiguration;
+import jenkins.security.QueueItemAuthenticatorDescriptor;
+import org.jenkinsci.plugins.authorizeproject.strategy.AnonymousAuthorizationStrategy;
+import org.jenkinsci.plugins.authorizeproject.strategy.SpecificUsersAuthorizationStrategy;
+import org.jenkinsci.plugins.authorizeproject.strategy.SystemAuthorizationStrategy;
+import org.jenkinsci.plugins.authorizeproject.strategy.TriggeringUsersAuthorizationStrategy;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.recipes.LocalData;
+
+public class ConfigurationAsCodeTest {
+
+    @Rule public JenkinsConfiguredWithCodeRule r = new JenkinsConfiguredWithCodeRule();
+
+    @Test
+    @ConfiguredWithCode("ConfigurationAsCodeTest/global.config.AnonymousAuthorizationStrategy.yml")
+    public void importGlobalAnonymousAuthorizationStrategy() {
+        DescribableList<QueueItemAuthenticator, QueueItemAuthenticatorDescriptor> authenticators = QueueItemAuthenticatorConfiguration.get().getAuthenticators();
+        GlobalQueueItemAuthenticator queueItemAuthenticator = authenticators.get(GlobalQueueItemAuthenticator.class);
+
+        assertThat(authenticators, hasSize(1));
+        assertThat(queueItemAuthenticator.getStrategy(), instanceOf(AnonymousAuthorizationStrategy.class));
+    }
+
+    @Test
+    @ConfiguredWithCode("ConfigurationAsCodeTest/global.config.AnonymousAuthorizationStrategy.yml")
+    public void exportGlobalAnonymousAuthorizationStrategy() throws Exception {
+        assertExport("ConfigurationAsCodeTest/global.export.AnonymousAuthorizationStrategy.yml");
+    }
+
+    @Test
+    @ConfiguredWithCode("ConfigurationAsCodeTest/global.config.SpecificUsersAuthorizationStrategy.yml")
+    public void importGlobalSpecificUsersAuthorizationStrategy() {
+        DescribableList<QueueItemAuthenticator, QueueItemAuthenticatorDescriptor> authenticators = QueueItemAuthenticatorConfiguration.get().getAuthenticators();
+        GlobalQueueItemAuthenticator queueItemAuthenticator = authenticators.get(GlobalQueueItemAuthenticator.class);
+
+        assertThat(authenticators, hasSize(1));
+        assertThat(queueItemAuthenticator.getStrategy(), instanceOf(SpecificUsersAuthorizationStrategy.class));
+        assertThat(((SpecificUsersAuthorizationStrategy) queueItemAuthenticator.getStrategy()).getUserid(), equalTo("some-user"));
+    }
+
+    @Test
+    @ConfiguredWithCode("ConfigurationAsCodeTest/global.config.SpecificUsersAuthorizationStrategy.yml")
+    public void exportGlobalSpecificUsersAuthorizationStrategy() throws Exception {
+        assertExport("ConfigurationAsCodeTest/global.export.SpecificUsersAuthorizationStrategy.yml");
+    }
+
+    @Test
+    @ConfiguredWithCode("ConfigurationAsCodeTest/global.config.SystemAuthorizationStrategy.yml")
+    public void importGlobalSystemAuthorizationStrategy() {
+        DescribableList<QueueItemAuthenticator, QueueItemAuthenticatorDescriptor> authenticators = QueueItemAuthenticatorConfiguration.get().getAuthenticators();
+        GlobalQueueItemAuthenticator queueItemAuthenticator = authenticators.get(GlobalQueueItemAuthenticator.class);
+
+        assertThat(authenticators, hasSize(1));
+        assertThat(queueItemAuthenticator.getStrategy(), instanceOf(SystemAuthorizationStrategy.class));
+    }
+
+    @Test
+    @ConfiguredWithCode("ConfigurationAsCodeTest/global.config.SystemAuthorizationStrategy.yml")
+    public void exportGlobalSystemAuthorizationStrategy() throws Exception {
+        assertExport("ConfigurationAsCodeTest/global.export.SystemAuthorizationStrategy.yml");
+    }
+
+    @Test
+    @ConfiguredWithCode("ConfigurationAsCodeTest/global.config.TriggeringUsersAuthorizationStrategy.yml")
+    public void importGlobalTriggeringUsersAuthorizationStrategy() {
+        DescribableList<QueueItemAuthenticator, QueueItemAuthenticatorDescriptor> authenticators = QueueItemAuthenticatorConfiguration.get().getAuthenticators();
+        GlobalQueueItemAuthenticator queueItemAuthenticator = authenticators.get(GlobalQueueItemAuthenticator.class);
+
+        assertThat(authenticators, hasSize(1));
+        assertThat(queueItemAuthenticator.getStrategy(), instanceOf(TriggeringUsersAuthorizationStrategy.class));
+    }
+
+    @Test
+    @ConfiguredWithCode("ConfigurationAsCodeTest/global.config.TriggeringUsersAuthorizationStrategy.yml")
+    public void exportGlobalTriggeringUsersAuthorizationStrategy() throws Exception {
+        assertExport("ConfigurationAsCodeTest/global.export.TriggeringUsersAuthorizationStrategy.yml");
+    }
+
+    @Test
+    @ConfiguredWithCode("ConfigurationAsCodeTest/project.config.all.yml")
+    public void importProjectTriggeringUsersAuthorizationStrategy() {
+        DescribableList<QueueItemAuthenticator, QueueItemAuthenticatorDescriptor> authenticators = QueueItemAuthenticatorConfiguration.get().getAuthenticators();
+        ProjectQueueItemAuthenticator queueItemAuthenticator = authenticators.get(ProjectQueueItemAuthenticator.class);
+
+        assertThat(authenticators, hasSize(1));
+        assertThat(queueItemAuthenticator.getDisabledStrategies(), equalTo(new HashSet<>(Arrays.asList("org.jenkinsci.plugins.authorizeproject.strategy.SystemAuthorizationStrategy", "org.jenkinsci.plugins.authorizeproject.strategy.SpecificUsersAuthorizationStrategy", "org.jenkinsci.plugins.authorizeproject.strategy.TriggeringUsersAuthorizationStrategy"))));
+        assertThat(queueItemAuthenticator.getEnabledStrategies(), equalTo(new HashSet<>(Arrays.asList("org.jenkinsci.plugins.authorizeproject.strategy.AnonymousAuthorizationStrategy"))));
+    }
+
+    @Test
+    @ConfiguredWithCode("ConfigurationAsCodeTest/project.config.all.yml")
+    public void exportProjectTriggeringUsersAuthorizationStrategy() throws Exception {
+        assertExport("ConfigurationAsCodeTest/project.export.all.yml");
+    }
+
+    private void assertExport(String resourcePath) throws Exception {
+        ConfiguratorRegistry registry = ConfiguratorRegistry.get();
+        ConfigurationContext context = new ConfigurationContext(registry);
+        CNode queueItemAuthenticator = Util.getSecurityRoot(context).get("queueItemAuthenticator");
+
+        String exported = Util.toYamlString(queueItemAuthenticator);
+        String expected = Util.toStringFromYamlFile(this, resourcePath);
+
+        assertThat(exported, equalTo(expected));
+    }
+
+    @LocalData
+    @Test
+    public void strategyEnabledMapMigration() {
+        DescribableList<QueueItemAuthenticator, QueueItemAuthenticatorDescriptor> authenticators = QueueItemAuthenticatorConfiguration.get().getAuthenticators();
+        ProjectQueueItemAuthenticator queueItemAuthenticator = authenticators.get(ProjectQueueItemAuthenticator.class);
+
+        assertThat(authenticators, hasSize(1));
+        assertThat(queueItemAuthenticator.getDisabledStrategies(), equalTo(new HashSet<>(Arrays.asList(SpecificUsersAuthorizationStrategy.class.getName(), SystemAuthorizationStrategy.class.getName()))));
+        assertThat(queueItemAuthenticator.getEnabledStrategies(), equalTo(new HashSet<>(Arrays.asList(AnonymousAuthorizationStrategy.class.getName(), TriggeringUsersAuthorizationStrategy.class.getName()))));
+    }
+}

--- a/src/test/resources/org/jenkinsci/plugins/authorizeproject/ConfigurationAsCodeTest/global.config.AnonymousAuthorizationStrategy.yml
+++ b/src/test/resources/org/jenkinsci/plugins/authorizeproject/ConfigurationAsCodeTest/global.config.AnonymousAuthorizationStrategy.yml
@@ -1,0 +1,5 @@
+security:
+  queueItemAuthenticator:
+    authenticators:
+      - global:
+          strategy: "anonymousAuthorizationStrategy"

--- a/src/test/resources/org/jenkinsci/plugins/authorizeproject/ConfigurationAsCodeTest/global.config.SpecificUsersAuthorizationStrategy.yml
+++ b/src/test/resources/org/jenkinsci/plugins/authorizeproject/ConfigurationAsCodeTest/global.config.SpecificUsersAuthorizationStrategy.yml
@@ -1,0 +1,8 @@
+security:
+  queueItemAuthenticator:
+    authenticators:
+      - global:
+          strategy:
+            specificUsersAuthorizationStrategy:
+              dontRestrictJobConfiguration: true
+              userid: "some-user"

--- a/src/test/resources/org/jenkinsci/plugins/authorizeproject/ConfigurationAsCodeTest/global.config.SystemAuthorizationStrategy.yml
+++ b/src/test/resources/org/jenkinsci/plugins/authorizeproject/ConfigurationAsCodeTest/global.config.SystemAuthorizationStrategy.yml
@@ -1,0 +1,5 @@
+security:
+  queueItemAuthenticator:
+    authenticators:
+      - global:
+          strategy: "systemAuthorizationStrategy"

--- a/src/test/resources/org/jenkinsci/plugins/authorizeproject/ConfigurationAsCodeTest/global.config.TriggeringUsersAuthorizationStrategy.yml
+++ b/src/test/resources/org/jenkinsci/plugins/authorizeproject/ConfigurationAsCodeTest/global.config.TriggeringUsersAuthorizationStrategy.yml
@@ -1,0 +1,5 @@
+security:
+  queueItemAuthenticator:
+    authenticators:
+      - global:
+          strategy: "triggeringUsersAuthorizationStrategy"

--- a/src/test/resources/org/jenkinsci/plugins/authorizeproject/ConfigurationAsCodeTest/global.export.AnonymousAuthorizationStrategy.yml
+++ b/src/test/resources/org/jenkinsci/plugins/authorizeproject/ConfigurationAsCodeTest/global.export.AnonymousAuthorizationStrategy.yml
@@ -1,0 +1,3 @@
+authenticators:
+- global:
+    strategy: "anonymousAuthorizationStrategy"

--- a/src/test/resources/org/jenkinsci/plugins/authorizeproject/ConfigurationAsCodeTest/global.export.SpecificUsersAuthorizationStrategy.yml
+++ b/src/test/resources/org/jenkinsci/plugins/authorizeproject/ConfigurationAsCodeTest/global.export.SpecificUsersAuthorizationStrategy.yml
@@ -1,0 +1,6 @@
+authenticators:
+- global:
+    strategy:
+      specificUsersAuthorizationStrategy:
+        dontRestrictJobConfiguration: true
+        userid: "some-user"

--- a/src/test/resources/org/jenkinsci/plugins/authorizeproject/ConfigurationAsCodeTest/global.export.SystemAuthorizationStrategy.yml
+++ b/src/test/resources/org/jenkinsci/plugins/authorizeproject/ConfigurationAsCodeTest/global.export.SystemAuthorizationStrategy.yml
@@ -1,0 +1,3 @@
+authenticators:
+- global:
+    strategy: "systemAuthorizationStrategy"

--- a/src/test/resources/org/jenkinsci/plugins/authorizeproject/ConfigurationAsCodeTest/global.export.TriggeringUsersAuthorizationStrategy.yml
+++ b/src/test/resources/org/jenkinsci/plugins/authorizeproject/ConfigurationAsCodeTest/global.export.TriggeringUsersAuthorizationStrategy.yml
@@ -1,0 +1,3 @@
+authenticators:
+- global:
+    strategy: "triggeringUsersAuthorizationStrategy"

--- a/src/test/resources/org/jenkinsci/plugins/authorizeproject/ConfigurationAsCodeTest/project.config.all.yml
+++ b/src/test/resources/org/jenkinsci/plugins/authorizeproject/ConfigurationAsCodeTest/project.config.all.yml
@@ -1,0 +1,10 @@
+security:
+  queueItemAuthenticator:
+    authenticators:
+      - project:
+          disabledStrategies:
+            - "org.jenkinsci.plugins.authorizeproject.strategy.SystemAuthorizationStrategy"
+            - "org.jenkinsci.plugins.authorizeproject.strategy.SpecificUsersAuthorizationStrategy"
+            - "org.jenkinsci.plugins.authorizeproject.strategy.TriggeringUsersAuthorizationStrategy"
+          enabledStrategies:
+            - "org.jenkinsci.plugins.authorizeproject.strategy.AnonymousAuthorizationStrategy"

--- a/src/test/resources/org/jenkinsci/plugins/authorizeproject/ConfigurationAsCodeTest/project.export.all.yml
+++ b/src/test/resources/org/jenkinsci/plugins/authorizeproject/ConfigurationAsCodeTest/project.export.all.yml
@@ -1,0 +1,8 @@
+authenticators:
+- project:
+    disabledStrategies:
+    - "org.jenkinsci.plugins.authorizeproject.strategy.SpecificUsersAuthorizationStrategy"
+    - "org.jenkinsci.plugins.authorizeproject.strategy.TriggeringUsersAuthorizationStrategy"
+    - "org.jenkinsci.plugins.authorizeproject.strategy.SystemAuthorizationStrategy"
+    enabledStrategies:
+    - "org.jenkinsci.plugins.authorizeproject.strategy.AnonymousAuthorizationStrategy"

--- a/src/test/resources/org/jenkinsci/plugins/authorizeproject/ConfigurationAsCodeTest/strategyEnabledMapMigration/jenkins.security.QueueItemAuthenticatorConfiguration.xml
+++ b/src/test/resources/org/jenkinsci/plugins/authorizeproject/ConfigurationAsCodeTest/strategyEnabledMapMigration/jenkins.security.QueueItemAuthenticatorConfiguration.xml
@@ -1,0 +1,25 @@
+<?xml version='1.1' encoding='UTF-8'?>
+<jenkins.security.QueueItemAuthenticatorConfiguration>
+  <authenticators>
+    <org.jenkinsci.plugins.authorizeproject.ProjectQueueItemAuthenticator plugin="authorize-project@1.4.0">
+      <strategyEnabledMap>
+        <entry>
+          <string>org.jenkinsci.plugins.authorizeproject.strategy.SpecificUsersAuthorizationStrategy</string>
+          <boolean>false</boolean>
+        </entry>
+        <entry>
+          <string>org.jenkinsci.plugins.authorizeproject.strategy.TriggeringUsersAuthorizationStrategy</string>
+          <boolean>true</boolean>
+        </entry>
+        <entry>
+          <string>org.jenkinsci.plugins.authorizeproject.strategy.SystemAuthorizationStrategy</string>
+          <boolean>false</boolean>
+        </entry>
+        <entry>
+          <string>org.jenkinsci.plugins.authorizeproject.strategy.AnonymousAuthorizationStrategy</string>
+          <boolean>true</boolean>
+        </entry>
+      </strategyEnabledMap>
+    </org.jenkinsci.plugins.authorizeproject.ProjectQueueItemAuthenticator>
+  </authenticators>
+</jenkins.security.QueueItemAuthenticatorConfiguration>


### PR DESCRIPTION
See [JENKINS-56774](https://issues.jenkins.io/browse/JENKINS-56774). Completes the work started in #44:

- Converts all usages of deprecated functionality in production and test code to use the non-deprecated equivalents being introduced in this PR.
- Adds a new `@LocalData`-based test to test the migration of the per-project datastructure from a map to two sets.
- The new test showed that the original change was incorrectly using short names rather than FQCNs for `enabledStrategies` and `disabledStrategies`. Adapted the examples in the test suite accordingly.
- Generated XML files for the old style configuration in the UI with the old version of the plugin, then applied each of the YAML files from the test suite and verified manually that the resulting XML correct.
- Configured a bunch of settings in the UI with the old version of this plugin, then did a JCasC export with these changes and verified that the result looked correct.
- Tested end-to-end with Job DSL [Groovy Sandboxing](https://github.com/jenkinsci/job-dsl-plugin/wiki/Script-Security#groovy-sandboxing).