### PR TITLE
Remove divBasedFormLayout conditional from jelly files

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/authorizeproject/AuthorizeProjectProperty/AuthorizationAction/index.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/authorizeproject/AuthorizeProjectProperty/AuthorizationAction/index.jelly
@@ -26,36 +26,6 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout"
          xmlns:f="/lib/form" xmlns:t="/lib/hudson" xmlns:d="jelly:define"
          xmlns:local="local">
-  <d:taglib uri="local">
-    <d:tag name="blockWrapperTr">
-      <j:choose>
-        <j:when test="${divBasedFormLayout}">
-          <div>
-            <d:invokeBody/>
-          </div>
-        </j:when>
-        <j:otherwise>
-          <tr>
-            <d:invokeBody/>
-          </tr>
-        </j:otherwise>
-      </j:choose>
-    </d:tag>
-    <d:tag name="blockWrapperTd">
-      <j:choose>
-        <j:when test="${divBasedFormLayout}">
-          <div>
-            <d:invokeBody/>
-          </div>
-        </j:when>
-        <j:otherwise>
-          <td>
-            <d:invokeBody/>
-          </td>
-        </j:otherwise>
-      </j:choose>
-    </d:tag>
-  </d:taglib>
   <l:layout title="${it.displayName}" norefresh="true" permission="${it.job.CONFIGURE}">
     <st:include it="${it.job}" page="sidepanel" optional="true"/>
     <l:main-panel>
@@ -67,11 +37,9 @@
       <p/>
       <div class="behavior-loading">${%LOADING}</div>
       <f:form action="authorize" method="post" name="config">
-        <local:blockWrapperTr>
-          <local:blockWrapperTd>
-            <input type="hidden" name="stapler-class-bag" value="true"/>
-          </local:blockWrapperTd>
-        </local:blockWrapperTr>
+        <div>
+          <input type="hidden" name="stapler-class-bag" value="true"/>
+        </div>
         <j:set var="instance" value="${it.property}"/>
         <j:set var="descriptor" value="${it.propertyDescriptor}"/>
         <f:optionalBlock name="${descriptor.jsonSafeClassName}" help="${descriptor.helpFile}"

--- a/src/main/resources/org/jenkinsci/plugins/authorizeproject/ProjectQueueItemAuthenticator/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/authorizeproject/ProjectQueueItemAuthenticator/config.jelly
@@ -23,26 +23,9 @@ THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:local="local">
-  <d:taglib uri="local">
-    <d:tag name="blockWrapperTable" >
-      <j:choose>
-        <j:when test="${divBasedFormLayout}">
-          <div>
-
-            <d:invokeBody/>
-          </div>
-        </j:when>
-        <j:otherwise>
-          <table width="100%">
-            <d:invokeBody/>
-          </table>
-        </j:otherwise>
-      </j:choose>
-    </d:tag>
-  </d:taglib>
 <!-- configurations for AuthorizeProjectStrategy -->
   <f:entry title="${%Strategies}">
-    <local:blockWrapperTable>
+    <div>
       <j:forEach var="d" items="${descriptor.availableDescriptorList}">
         <j:scope>
           <j:set var="checked" value="${instance==null?d.enabledByDefault: instance.isStrategyEnabled(d)}" />
@@ -54,6 +37,6 @@ THE SOFTWARE.
           </f:optionalBlock>
         </j:scope>
       </j:forEach>
-    </local:blockWrapperTable>
+    </div>
   </f:entry>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/authorizeproject/strategy/SpecificUsersAuthorizationStrategy/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/authorizeproject/strategy/SpecificUsersAuthorizationStrategy/config.jelly
@@ -23,25 +23,8 @@ THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:local="local">
-  <d:taglib uri="local">
-    <d:tag name="blockWrapperTable" >
-      <j:choose>
-        <j:when test="${divBasedFormLayout}">
-          <div class="specific-user-authorization">
-
-            <d:invokeBody/>
-          </div>
-        </j:when>
-        <j:otherwise>
-          <table style="width:100%" class="specific-user-authorization">
-            <d:invokeBody/>
-          </table>
-        </j:otherwise>
-      </j:choose>
-    </d:tag>
-  </d:taglib>
   <f:block>
-  <local:blockWrapperTable>
+  <div class="specific-user-authorization">
   <!--
     hetero-radio makes entries visible even they are hidden.
     So nest it not to handled by hetero-radio.
@@ -63,7 +46,7 @@ THE SOFTWARE.
     <f:checkbox />
   </f:entry>
   </j:if> <!-- authorizeProjectContext -->
-  </local:blockWrapperTable>
+  </div>
   <j:if test="${authorizeProjectContext != 'global'}">
   <st:once>
     <st:adjunct includes="org.jenkinsci.plugins.authorizeproject.strategy.SpecificUsersAuthorizationStrategy.checkPasswordRequested" />


### PR DESCRIPTION
## Remove divBasedFormLayout from jelly files

Jenkins minimum version is now 2.375.4, the conditional is always true.

### Testing done:

* Modified the updated jelly files and confirmed that I saw each of the modified pages during my testing (debugging strings added temporarily, removed before final commit)
* Defined a freestyle job and confirmed it ran as expected without access control enabled
* Defined a Pipeline job and confirmed it ran as expected without access control enabled
* Enabled access control for builds and allowed "Run as Specific User", "Run as User who Triggered Build", and "Run as anonymous".  Confirmed that the setting was honored in the freestyle job and the Pipeline job

Testing detected a mismatched `div` tag.  That was fixed during testing.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
