### PR TITLE
Format Java and pom with parent pom 4.59

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,3 @@
+# .git-blame-ignore-revs
+# Formatted sources with parent pom 4.59
+bc9514366a7571c8373a926b664bf40add9ea0ee

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.58</version>
+    <version>4.59</version>
     <relativePath />
   </parent>
 
@@ -15,12 +15,13 @@
   <description>Configure projects to run with specified authorization.</description>
   <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
 
-  <scm>
-    <connection>scm:git:https://github.com/${gitHubRepo}.git</connection>
-    <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
-    <url>https://github.com/${gitHubRepo}</url>
-    <tag>${scmTag}</tag>
-  </scm>
+  <licenses>
+    <license>
+      <name>The MIT license</name>
+      <url>https://opensource.org/licenses/MIT</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
 
   <developers>
     <developer>
@@ -29,13 +30,12 @@
     </developer>
   </developers>
 
-  <licenses>
-    <license>
-      <name>The MIT license</name>
-      <url>https://opensource.org/licenses/MIT</url>
-      <distribution>repo</distribution>
-    </license>
-  </licenses>
+  <scm>
+    <connection>scm:git:https://github.com/${gitHubRepo}.git</connection>
+    <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
+    <tag>${scmTag}</tag>
+    <url>https://github.com/${gitHubRepo}</url>
+  </scm>
 
   <properties>
     <revision>1.5.2</revision>
@@ -52,16 +52,37 @@
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-2.375.x</artifactId>
         <version>1968.vb_14a_29e76128</version>
-        <scope>import</scope>
         <type>pom</type>
+        <scope>import</scope>
       </dependency>
     </dependencies>
   </dependencyManagement>
 
   <dependencies>
     <dependency>
-      <groupId>org.jenkins-ci.plugins.workflow</groupId>
-      <artifactId>workflow-job</artifactId>
+      <groupId>io.jenkins</groupId>
+      <artifactId>configuration-as-code</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.jenkins.configuration-as-code</groupId>
+      <artifactId>test-harness</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>matrix-auth</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>matrix-project</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <!-- Required to avoid cyclic dependency -->
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>script-security</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -75,45 +96,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>io.jenkins</groupId>
-      <artifactId>configuration-as-code</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.jenkins.configuration-as-code</groupId>
-      <artifactId>test-harness</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <!-- Required to avoid cyclic dependency -->
-    <dependency>
-      <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>script-security</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>matrix-project</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>matrix-auth</artifactId>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-job</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>
-
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.jenkins-ci.tools</groupId>
-        <artifactId>maven-hpi-plugin</artifactId>
-        <extensions>true</extensions>
-        <configuration>
-          <compatibleSinceVersion>1.3.0</compatibleSinceVersion>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
 
   <repositories>
     <repository>
@@ -128,5 +115,18 @@
       <url>https://repo.jenkins-ci.org/public/</url>
     </pluginRepository>
   </pluginRepositories>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.jenkins-ci.tools</groupId>
+        <artifactId>maven-hpi-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <compatibleSinceVersion>1.3.0</compatibleSinceVersion>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 
 </project>

--- a/src/main/java/org/jenkinsci/plugins/authorizeproject/AuthorizeProjectProperty.java
+++ b/src/main/java/org/jenkinsci/plugins/authorizeproject/AuthorizeProjectProperty.java
@@ -1,18 +1,18 @@
 /*
  * The MIT License
- * 
+ *
  * Copyright (c) 2013 IKEDA Yasuyuki
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -24,6 +24,8 @@
 
 package org.jenkinsci.plugins.authorizeproject;
 
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.BulkChange;
 import hudson.DescriptorExtensionList;
 import hudson.Extension;
@@ -43,8 +45,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import edu.umd.cs.findbugs.annotations.CheckForNull;
-import edu.umd.cs.findbugs.annotations.NonNull;
 import javax.servlet.ServletException;
 import jenkins.model.Jenkins;
 import jenkins.model.TransientActionFactory;
@@ -100,14 +100,12 @@ public class AuthorizeProjectProperty extends JobProperty<Job<?, ?>> {
             return null;
         }
         if (DescriptorVisibilityFilter.apply(
-                ProjectQueueItemAuthenticator.getConfigured(),
-                List.of(strategy.getDescriptor())
-        ).isEmpty()) {
+                        ProjectQueueItemAuthenticator.getConfigured(), List.of(strategy.getDescriptor()))
+                .isEmpty()) {
             LOGGER.log(
                     Level.WARNING,
                     "{0} is configured but disabled in the global-security configuration.",
-                    strategy.getDescriptor().getDisplayName()
-            );
+                    strategy.getDescriptor().getDisplayName());
             return null;
         }
         return strategy;
@@ -182,7 +180,7 @@ public class AuthorizeProjectProperty extends JobProperty<Job<?, ?>> {
          */
         @Deprecated
         public DescriptorExtensionList<AuthorizeProjectStrategy, Descriptor<AuthorizeProjectStrategy>>
-        getStrategyList() {
+                getStrategyList() {
             return AuthorizeProjectStrategy.all();
         }
 
@@ -196,7 +194,6 @@ public class AuthorizeProjectProperty extends JobProperty<Job<?, ?>> {
             }
             return DescriptorVisibilityFilter.apply(authenticator, AuthorizeProjectStrategy.all());
         }
-
     }
 
     /**
@@ -305,12 +302,11 @@ public class AuthorizeProjectProperty extends JobProperty<Job<?, ?>> {
                 job.save();
                 bc.commit();
                 return FormApply.success("../");
-            } catch (IOException e){
+            } catch (IOException e) {
                 bc.abort();
                 throw e;
             }
         }
-
     }
 
     /**
@@ -319,7 +315,7 @@ public class AuthorizeProjectProperty extends JobProperty<Job<?, ?>> {
      * @since 1.3.0
      */
     @SuppressWarnings("rawtypes")
-    @Extension(ordinal = Double.MAX_VALUE / 2)  // close to the top
+    @Extension(ordinal = Double.MAX_VALUE / 2) // close to the top
     public static class TransientActionFactoryImpl extends TransientActionFactory<Job> {
 
         /**

--- a/src/main/java/org/jenkinsci/plugins/authorizeproject/AuthorizeProjectStrategy.java
+++ b/src/main/java/org/jenkinsci/plugins/authorizeproject/AuthorizeProjectStrategy.java
@@ -1,18 +1,18 @@
 /*
  * The MIT License
- * 
+ *
  * Copyright (c) 2013 IKEDA Yasuyuki
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -34,7 +34,6 @@ import hudson.model.Job;
 import hudson.model.Queue;
 import hudson.security.ACL;
 import hudson.security.AccessControlled;
-
 import java.io.InvalidObjectException;
 import java.io.ObjectStreamException;
 import java.util.logging.Level;
@@ -57,37 +56,31 @@ public abstract class AuthorizeProjectStrategy extends AbstractDescribableImpl<A
     public static DescriptorExtensionList<AuthorizeProjectStrategy, Descriptor<AuthorizeProjectStrategy>> all() {
         return Jenkins.get().getDescriptorList(AuthorizeProjectStrategy.class);
     }
-    
+
     /**
      * Returns the {@link Authentication} for the build.
-     * 
+     *
      * @param project the project to run.
      * @param item the item in queue, which will be a build.
      * @return {@code true} if authentication was successful
      */
     public Authentication authenticate(Job<?, ?> project, Queue.Item item) {
-        if(!Util.isOverridden(
-                AuthorizeProjectStrategy.class,
-                getClass(),
-                "authenticate",
-                AbstractProject.class,
-                Queue.Item.class
-        )) {
+        if (!Util.isOverridden(
+                AuthorizeProjectStrategy.class, getClass(), "authenticate", AbstractProject.class, Queue.Item.class)) {
             throw new AbstractMethodError();
         }
-        
+
         if (!(project instanceof AbstractProject)) {
             Descriptor<?> d = Jenkins.get().getDescriptor(getClass());
             LOGGER.log(
                     Level.WARNING,
                     "This authorization strategy ({0}) is designed for authorize-project < 1.1.0 and not applicable for non-AbstractProjects (like WorkflowJob). ignored.",
-                    (d != null)?d.getDisplayName():getClass().getName()
-            );
+                    (d != null) ? d.getDisplayName() : getClass().getName());
             return null;
         }
-        return authenticate((AbstractProject<?,?>)project, item);
+        return authenticate((AbstractProject<?, ?>) project, item);
     }
-    
+
     /**
      * Old {@link AbstractProject} based version of {@link #authenticate(Job, Queue.Item)}.
      *
@@ -98,7 +91,7 @@ public abstract class AuthorizeProjectStrategy extends AbstractDescribableImpl<A
      */
     @Deprecated
     public Authentication authenticate(AbstractProject<?, ?> project, Queue.Item item) {
-        return authenticate((Job<?,?>)project, item);
+        return authenticate((Job<?, ?>) project, item);
     }
 
     /**
@@ -106,7 +99,7 @@ public abstract class AuthorizeProjectStrategy extends AbstractDescribableImpl<A
      */
     @Override
     public AuthorizeProjectStrategyDescriptor getDescriptor() {
-        return (AuthorizeProjectStrategyDescriptor)super.getDescriptor();
+        return (AuthorizeProjectStrategyDescriptor) super.getDescriptor();
     }
 
     /**
@@ -119,11 +112,10 @@ public abstract class AuthorizeProjectStrategy extends AbstractDescribableImpl<A
     public final void checkJobConfigurePermission(AccessControlled context) {
         if (!hasJobConfigurePermission(context)) {
             throw new AccessDeniedException(Messages.AuthorizeProjectStrategy_UserNotAuthorizedForJob(
-                    Jenkins.getAuthentication().getName()
-            ));
+                    Jenkins.getAuthentication().getName()));
         }
     }
-    
+
     /**
      * Tests if the job can be reconfigured by the current user when this strategy is the configured strategy.
      * Users with {@link Jenkins#ADMINISTER} permission skips this check.
@@ -146,8 +138,7 @@ public abstract class AuthorizeProjectStrategy extends AbstractDescribableImpl<A
     public final void checkAuthorizationConfigurePermission(AccessControlled context) {
         if (!hasAuthorizationConfigurePermission(context)) {
             throw new AccessDeniedException(Messages.AuthorizeProjectStrategy_UserNotAuthorized(
-                    Jenkins.getAuthentication().getName()
-            ));
+                    Jenkins.getAuthentication().getName()));
         }
     }
 

--- a/src/main/java/org/jenkinsci/plugins/authorizeproject/AuthorizeProjectStrategyDescriptor.java
+++ b/src/main/java/org/jenkinsci/plugins/authorizeproject/AuthorizeProjectStrategyDescriptor.java
@@ -1,18 +1,18 @@
 /*
  * The MIT License
- * 
+ *
  * Copyright (c) 2013 IKEDA Yasuyuki
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -25,30 +25,26 @@
 package org.jenkinsci.plugins.authorizeproject;
 
 import hudson.XmlFile;
-import java.util.ArrayList;
-import java.util.List;
-
-import net.sf.json.JSONObject;
-
-import org.kohsuke.stapler.StaplerRequest;
-
 import hudson.model.Descriptor;
 import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
 import jenkins.model.Jenkins;
+import net.sf.json.JSONObject;
+import org.kohsuke.stapler.StaplerRequest;
 
 /**
  * Base {@link Descriptor} class for {@link AuthorizeProjectStrategy} instances.
  */
 public abstract class AuthorizeProjectStrategyDescriptor extends Descriptor<AuthorizeProjectStrategy> {
-    
-    
+
     /**
      * {@inheritDoc}
      */
     protected AuthorizeProjectStrategyDescriptor() {
         super();
     }
-    
+
     /**
      * {@inheritDoc}
      */
@@ -61,15 +57,14 @@ public abstract class AuthorizeProjectStrategyDescriptor extends Descriptor<Auth
      */
     @Override
     protected final XmlFile getConfigFile() {
-        return new XmlFile(new File(Jenkins.get().getRootDir(),
-                Constants.CONFIG_FOLDER+"/"+getId()+".xml"));
+        return new XmlFile(new File(Jenkins.get().getRootDir(), Constants.CONFIG_FOLDER + "/" + getId() + ".xml"));
     }
-    
+
     /**
      * @return descriptors with configuration views in "Configure Global Security" as a child of {@link ProjectQueueItemAuthenticator}.
      */
     public String getGlobalSecurityConfigPage() {
-        for (String cand: getPossibleViewNames("global-security")) {
+        for (String cand : getPossibleViewNames("global-security")) {
             String page = getViewPage(clazz, cand);
             // Unfortunately, Descriptor#getViewPage returns passed value
             // when that view is not found.
@@ -82,38 +77,35 @@ public abstract class AuthorizeProjectStrategyDescriptor extends Descriptor<Auth
         }
         return null;
     }
-    
+
     /**
      * @return descriptors to display page in "Configure Global Security" as a child of {@link ProjectQueueItemAuthenticator}.
      */
     public static List<AuthorizeProjectStrategyDescriptor> getDescriptorsForGlobalSecurityConfigPage() {
         List<Descriptor<AuthorizeProjectStrategy>> all = AuthorizeProjectStrategy.all();
         List<AuthorizeProjectStrategyDescriptor> r = new ArrayList<>(all.size());
-        for (Descriptor<AuthorizeProjectStrategy> d: all) {
-            if (
-                    d instanceof AuthorizeProjectStrategyDescriptor
-                    && ((AuthorizeProjectStrategyDescriptor)d).getGlobalSecurityConfigPage() != null
-            ) {
-                r.add((AuthorizeProjectStrategyDescriptor)d);
+        for (Descriptor<AuthorizeProjectStrategy> d : all) {
+            if (d instanceof AuthorizeProjectStrategyDescriptor
+                    && ((AuthorizeProjectStrategyDescriptor) d).getGlobalSecurityConfigPage() != null) {
+                r.add((AuthorizeProjectStrategyDescriptor) d);
             }
         }
         return r;
     }
-    
+
     /**
      * Invoked when configuration is submitted from "Configure Global Security" as a child of {@link ProjectQueueItemAuthenticator}.
      * You should call save() by yourself.
      */
-    public void configureFromGlobalSecurity(StaplerRequest req, JSONObject js) throws FormException {
-    }
-    
+    public void configureFromGlobalSecurity(StaplerRequest req, JSONObject js) throws FormException {}
+
     /**
      * @return this strategy can be enabled by default.
      */
     public boolean isEnabledByDefault() {
         return true;
     }
-    
+
     /**
      * @return whether configurable for {@link GlobalQueueItemAuthenticator}
      * @since 1.2.0

--- a/src/main/java/org/jenkinsci/plugins/authorizeproject/AuthorizeProjectUtil.java
+++ b/src/main/java/org/jenkinsci/plugins/authorizeproject/AuthorizeProjectUtil.java
@@ -1,18 +1,18 @@
 /*
  * The MIT License
- * 
+ *
  * Copyright (c) 2016 IKEDA Yasuyuki
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -25,13 +25,11 @@
 package org.jenkinsci.plugins.authorizeproject;
 
 import edu.umd.cs.findbugs.annotations.CheckForNull;
-
-import jenkins.model.Jenkins;
 import hudson.model.Describable;
 import hudson.model.Descriptor;
 import hudson.model.Descriptor.FormException;
+import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
-
 import org.kohsuke.stapler.StaplerRequest;
 
 /**
@@ -42,41 +40,34 @@ public class AuthorizeProjectUtil {
      * Create a new {@link Describable} object from user inputs.
      */
     public static <T extends Describable<?>> T bindJSONWithDescriptor(
-            StaplerRequest req,
-            JSONObject formData,
-            String fieldName,
-            Class<T> clazz
-    ) throws FormException {
+            StaplerRequest req, JSONObject formData, String fieldName, Class<T> clazz) throws FormException {
         formData = formData.getJSONObject(fieldName);
         if (formData == null || formData.isNullObject()) {
             return null;
         }
         String staplerClazzName = formData.optString("$class", null);
         if (staplerClazzName == null) {
-          // Fall back on the legacy stapler-class attribute.
-          staplerClazzName = formData.optString("stapler-class", null);
+            // Fall back on the legacy stapler-class attribute.
+            staplerClazzName = formData.optString("stapler-class", null);
         }
         if (staplerClazzName == null) {
             throw new FormException("No $class is specified", fieldName);
         }
         try {
             @SuppressWarnings("unchecked")
-            Class<? extends T> staplerClass = (Class<? extends T>)Jenkins.get().getPluginManager().uberClassLoader.loadClass(staplerClazzName);
+            Class<? extends T> staplerClass = (Class<? extends T>)
+                    Jenkins.get().getPluginManager().uberClassLoader.loadClass(staplerClazzName);
             Descriptor<?> d = Jenkins.get().getDescriptorOrDie(staplerClass);
-            
+
             @SuppressWarnings("unchecked")
-            T instance = (T)d.newInstance(req, formData);
-            
+            T instance = (T) d.newInstance(req, formData);
+
             return instance;
-        } catch(ClassNotFoundException e) {
-            throw new FormException(
-                    String.format("Failed to instantiate %s", staplerClazzName),
-                    e,
-                    fieldName
-            );
+        } catch (ClassNotFoundException e) {
+            throw new FormException(String.format("Failed to instantiate %s", staplerClazzName), e, fieldName);
         }
     }
-    
+
     public static boolean userIdEquals(@CheckForNull String a, @CheckForNull String b) {
         if (a == null) {
             return b == null;

--- a/src/main/java/org/jenkinsci/plugins/authorizeproject/ConfigurationPermissionEnforcer.java
+++ b/src/main/java/org/jenkinsci/plugins/authorizeproject/ConfigurationPermissionEnforcer.java
@@ -1,5 +1,7 @@
 package org.jenkinsci.plugins.authorizeproject;
 
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.model.Job;
 import hudson.model.JobProperty;
@@ -7,10 +9,6 @@ import hudson.model.JobPropertyDescriptor;
 import hudson.security.AccessControlled;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
-
-import edu.umd.cs.findbugs.annotations.CheckForNull;
-import edu.umd.cs.findbugs.annotations.NonNull;
-
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -23,13 +21,12 @@ import org.kohsuke.stapler.StaplerRequest;
  * @since 1.3.0
  */
 @Restricted(NoExternalUse.class) // TODO remove this class once a fix for JENKINS-38219 is available in baseline core
-public class ConfigurationPermissionEnforcer extends JobProperty<Job<?,?>> {
+public class ConfigurationPermissionEnforcer extends JobProperty<Job<?, ?>> {
     /**
      * Our constructor.
      */
     @DataBoundConstructor
-    public ConfigurationPermissionEnforcer() {
-    }
+    public ConfigurationPermissionEnforcer() {}
 
     /**
      * Extension to perform the restriction.
@@ -51,7 +48,7 @@ public class ConfigurationPermissionEnforcer extends JobProperty<Job<?,?>> {
          */
         @Override
         public JobProperty<?> newInstance(@NonNull StaplerRequest req, JSONObject formData) throws FormException {
-            Job<?,?> job = req.findAncestorObject(Job.class);
+            Job<?, ?> job = req.findAncestorObject(Job.class);
             AccessControlled context = req.findAncestorObject(AccessControlled.class);
             checkConfigurePermission(job, context);
             // we don't actually return a job property... just want to be called on every form submission.
@@ -69,7 +66,7 @@ public class ConfigurationPermissionEnforcer extends JobProperty<Job<?,?>> {
             if (Jenkins.get().hasPermission(Jenkins.ADMINISTER)) {
                 // allows any configurations by system administrators.
                 // It may not be allowed even if the user is an administrator of the job,
-                // 
+                //
                 return;
             }
             AuthorizeProjectProperty property = job.getProperty(AuthorizeProjectProperty.class);

--- a/src/main/java/org/jenkinsci/plugins/authorizeproject/GlobalQueueItemAuthenticator.java
+++ b/src/main/java/org/jenkinsci/plugins/authorizeproject/GlobalQueueItemAuthenticator.java
@@ -8,7 +8,6 @@ import java.util.stream.Collectors;
 import jenkins.security.QueueItemAuthenticator;
 import jenkins.security.QueueItemAuthenticatorDescriptor;
 import net.sf.json.JSONObject;
-
 import org.acegisecurity.Authentication;
 import org.jenkinsci.plugins.authorizeproject.strategy.AnonymousAuthorizationStrategy;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -50,12 +49,14 @@ public class GlobalQueueItemAuthenticator extends QueueItemAuthenticator {
          * @return Descriptors for {@link AuthorizeProjectStrategy} applicable to {@link GlobalQueueItemAuthenticator}.
          */
         public Iterable<Descriptor<AuthorizeProjectStrategy>> getStrategyDescriptors() {
-            return AuthorizeProjectStrategy.all().stream().filter(d -> {
-                            if (!(d instanceof AuthorizeProjectStrategyDescriptor)) {
-                                return true;
-                            }
-                            return ((AuthorizeProjectStrategyDescriptor)d).isApplicableToGlobal();
-            }).collect(Collectors.toList());
+            return AuthorizeProjectStrategy.all().stream()
+                    .filter(d -> {
+                        if (!(d instanceof AuthorizeProjectStrategyDescriptor)) {
+                            return true;
+                        }
+                        return ((AuthorizeProjectStrategyDescriptor) d).isApplicableToGlobal();
+                    })
+                    .collect(Collectors.toList());
         }
 
         public AuthorizeProjectStrategy getDefaultStrategy() {
@@ -66,18 +67,17 @@ public class GlobalQueueItemAuthenticator extends QueueItemAuthenticator {
          * Creates new {@link GlobalQueueItemAuthenticator} from inputs.
          * This is required to call {@link hudson.model.Descriptor#newInstance(StaplerRequest, JSONObject)}
          * of {@link AuthorizeProjectProperty}.
-         * 
+         *
          * @see hudson.model.Descriptor#newInstance(org.kohsuke.stapler.StaplerRequest, net.sf.json.JSONObject)
          */
         @Override
-        public GlobalQueueItemAuthenticator newInstance(StaplerRequest req, JSONObject formData)
-                throws FormException
-        {
-            if(formData == null || formData.isNullObject()) {
+        public GlobalQueueItemAuthenticator newInstance(StaplerRequest req, JSONObject formData) throws FormException {
+            if (formData == null || formData.isNullObject()) {
                 return null;
             }
-            AuthorizeProjectStrategy strategy = AuthorizeProjectUtil.bindJSONWithDescriptor(req, formData, "strategy", AuthorizeProjectStrategy.class);
-            
+            AuthorizeProjectStrategy strategy = AuthorizeProjectUtil.bindJSONWithDescriptor(
+                    req, formData, "strategy", AuthorizeProjectStrategy.class);
+
             return new GlobalQueueItemAuthenticator(strategy);
         }
     }

--- a/src/main/java/org/jenkinsci/plugins/authorizeproject/strategy/AnonymousAuthorizationStrategy.java
+++ b/src/main/java/org/jenkinsci/plugins/authorizeproject/strategy/AnonymousAuthorizationStrategy.java
@@ -1,18 +1,18 @@
 /*
  * The MIT License
- * 
+ *
  * Copyright (c) 2013 IKEDA Yasuyuki
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -24,11 +24,10 @@
 
 package org.jenkinsci.plugins.authorizeproject.strategy;
 
-import jenkins.model.Jenkins;
 import hudson.Extension;
 import hudson.model.Job;
 import hudson.model.Queue;
-
+import jenkins.model.Jenkins;
 import org.acegisecurity.Authentication;
 import org.jenkinsci.plugins.authorizeproject.AuthorizeProjectStrategy;
 import org.jenkinsci.plugins.authorizeproject.AuthorizeProjectStrategyDescriptor;
@@ -39,15 +38,14 @@ import org.kohsuke.stapler.DataBoundConstructor;
  */
 public class AnonymousAuthorizationStrategy extends AuthorizeProjectStrategy {
     /**
-     * 
+     *
      */
     @DataBoundConstructor
-    public AnonymousAuthorizationStrategy() {
-    }
-    
+    public AnonymousAuthorizationStrategy() {}
+
     /**
      * Authorize builds as anonymous.
-     * 
+     *
      * @return anonymous authorization
      * @see org.jenkinsci.plugins.authorizeproject.AuthorizeProjectStrategy#authenticate(hudson.model.Job, hudson.model.Queue.Item)
      */
@@ -55,7 +53,7 @@ public class AnonymousAuthorizationStrategy extends AuthorizeProjectStrategy {
     public Authentication authenticate(Job<?, ?> project, Queue.Item item) {
         return Jenkins.ANONYMOUS;
     }
-    
+
     /**
      *
      */

--- a/src/main/java/org/jenkinsci/plugins/authorizeproject/strategy/SpecificUsersAuthorizationStrategy.java
+++ b/src/main/java/org/jenkinsci/plugins/authorizeproject/strategy/SpecificUsersAuthorizationStrategy.java
@@ -1,18 +1,18 @@
 /*
  * The MIT License
- * 
+ *
  * Copyright (c) 2013 IKEDA Yasuyuki
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -33,7 +33,6 @@ import hudson.security.AbstractPasswordBasedSecurityRealm;
 import hudson.security.AccessControlled;
 import hudson.security.SecurityRealm;
 import hudson.util.FormValidation;
-
 import java.io.ObjectStreamException;
 import java.util.Map;
 import java.util.logging.Level;
@@ -63,7 +62,7 @@ import org.kohsuke.stapler.StaplerRequest;
 public class SpecificUsersAuthorizationStrategy extends AuthorizeProjectStrategy {
     private static Logger LOGGER = Logger.getLogger(SpecificUsersAuthorizationStrategy.class.getName());
     private final String userid;
-    
+
     /*
      * The fields "useApitoken", "apitoken", and "password" are part of the @DataBoundConstructor annotated constructor,
      * but they are only required for validation during form submission. They are put here and marked restricted and
@@ -78,11 +77,10 @@ public class SpecificUsersAuthorizationStrategy extends AuthorizeProjectStrategy
     @Restricted(DoNotUse.class)
     private transient String password;
 
-    private final static Authentication[] BUILTIN_USERS = {
-            ACL.SYSTEM,
-            Jenkins.ANONYMOUS,
+    private static final Authentication[] BUILTIN_USERS = {
+        ACL.SYSTEM, Jenkins.ANONYMOUS,
     };
-    
+
     /**
      * @return id of the user to run builds as.
      */
@@ -125,8 +123,8 @@ public class SpecificUsersAuthorizationStrategy extends AuthorizeProjectStrategy
     }
 
     @DataBoundConstructor
-    public SpecificUsersAuthorizationStrategy(String userid, boolean useApitoken,
-                                              String apitoken, String password) throws AccessDeniedException {
+    public SpecificUsersAuthorizationStrategy(String userid, boolean useApitoken, String apitoken, String password)
+            throws AccessDeniedException {
         this(userid);
         if (isAuthenticationRequired(getUserid()) && !authenticate(getUserid(), useApitoken, apitoken, password)) {
             throw new AccessDeniedException(Messages.SpecificUsersAuthorizationStrategy_userid_authenticate());
@@ -148,9 +146,11 @@ public class SpecificUsersAuthorizationStrategy extends AuthorizeProjectStrategy
         } else {
             if (password != null) {
                 try {
-                    Jenkins.get().getSecurityRealm().getSecurityComponents().manager.authenticate(
-                            new UsernamePasswordAuthenticationToken(userId, password)
-                    );
+                    Jenkins.get()
+                            .getSecurityRealm()
+                            .getSecurityComponents()
+                            .manager
+                            .authenticate(new UsernamePasswordAuthenticationToken(userId, password));
                     // supplied password matches
                     return true;
                 } catch (Exception e) { // handles any exception including NPE.
@@ -184,7 +184,7 @@ public class SpecificUsersAuthorizationStrategy extends AuthorizeProjectStrategy
      * Run builds as a specified user.
      * <p>
      * If the user is invalid, run as anonymous.
-     * 
+     *
      * @see org.jenkinsci.plugins.authorizeproject.AuthorizeProjectStrategy#authenticate(hudson.model.Job, hudson.model.Queue.Item)
      */
     @Override
@@ -225,29 +225,29 @@ public class SpecificUsersAuthorizationStrategy extends AuthorizeProjectStrategy
     /**
      * Return {@link SpecificUsersAuthorizationStrategy} configured in a project.
      */
-    protected static SpecificUsersAuthorizationStrategy getCurrentStrategy(Job<?,?> project) {
+    protected static SpecificUsersAuthorizationStrategy getCurrentStrategy(Job<?, ?> project) {
         if (project == null) {
             return null;
         }
-        
+
         AuthorizeProjectProperty prop = project.getProperty(AuthorizeProjectProperty.class);
         if (prop == null) {
             return null;
         }
-        
+
         if (!(prop.getStrategy() instanceof SpecificUsersAuthorizationStrategy)) {
             return null;
         }
-        
-        return (SpecificUsersAuthorizationStrategy)prop.getStrategy();
+
+        return (SpecificUsersAuthorizationStrategy) prop.getStrategy();
     }
-    
+
     /**
      * {@inheritDoc}
      */
     @Override
     protected Object readResolve() throws ObjectStreamException {
-        SpecificUsersAuthorizationStrategy self = (SpecificUsersAuthorizationStrategy)super.readResolve();
+        SpecificUsersAuthorizationStrategy self = (SpecificUsersAuthorizationStrategy) super.readResolve();
         if (self.noNeedReauthentication != null) {
             self.setDontRestrictJobConfiguration(self.noNeedReauthentication);
         }
@@ -267,7 +267,7 @@ public class SpecificUsersAuthorizationStrategy extends AuthorizeProjectStrategy
         public String getDisplayName() {
             return Messages.SpecificUsersAuthorizationStrategy_DisplayName();
         }
-        
+
         /**
          * Helper method for computing the check password URL.
          *
@@ -276,17 +276,16 @@ public class SpecificUsersAuthorizationStrategy extends AuthorizeProjectStrategy
         @Restricted(NoExternalUse.class) // used by stapler/jelly
         @SuppressWarnings("unused")
         public String calcCheckPasswordRequestedUrl() {
-            return String.format("'%s/%s/checkPasswordRequested' + qs(this).nearBy('userid')",
-                    getCurrentDescriptorByNameUrl(),
-                    getDescriptorUrl()
-            );
+            return String.format(
+                    "'%s/%s/checkPasswordRequested' + qs(this).nearBy('userid')",
+                    getCurrentDescriptorByNameUrl(), getDescriptorUrl());
         }
-        
+
         /**
          * Checks password field is required in configuration page.
          * <p>
          * This is called asynchronously.
-         * 
+         *
          * @param req the request.
          * @param userid the userid.
          * @return "true" if password field is required. this should be evaluated as JavaScript.
@@ -296,7 +295,7 @@ public class SpecificUsersAuthorizationStrategy extends AuthorizeProjectStrategy
         public String doCheckPasswordRequested(StaplerRequest req, @QueryParameter String userid) {
             return Boolean.toString(isAuthenticationRequired(userid.trim()));
         }
-        
+
         /**
          * Checks the userid against the blacklist of invalid users.
          * @param userid the userid
@@ -308,14 +307,14 @@ public class SpecificUsersAuthorizationStrategy extends AuthorizeProjectStrategy
             if (StringUtils.isBlank(userid)) {
                 return FormValidation.error(Messages.SpecificUsersAuthorizationStrategy_userid_required());
             }
-            for (Authentication a: BUILTIN_USERS) {
+            for (Authentication a : BUILTIN_USERS) {
                 if (AuthorizeProjectUtil.userIdEquals(userid, a.getPrincipal().toString())) {
                     return FormValidation.error(Messages.SpecificUsersAuthorizationStrategy_userid_builtin());
                 }
             }
             return FormValidation.ok();
         }
-        
+
         /**
          * Checks the supplied password.
          *
@@ -331,17 +330,16 @@ public class SpecificUsersAuthorizationStrategy extends AuthorizeProjectStrategy
                 @QueryParameter String userid,
                 @QueryParameter String password,
                 @QueryParameter String apitoken,
-                @QueryParameter boolean useApitoken
-        ) {
+                @QueryParameter boolean useApitoken) {
             if (!isAuthenticationRequired(userid.trim())) {
                 // authentication is not required.
                 return FormValidation.ok();
             }
-            
+
             if (useApitoken ? StringUtils.isBlank(apitoken) : StringUtils.isBlank(password)) {
                 return FormValidation.error(Messages.SpecificUsersAuthorizationStrategy_password_required());
             }
-            
+
             return FormValidation.ok();
         }
 
@@ -356,9 +354,11 @@ public class SpecificUsersAuthorizationStrategy extends AuthorizeProjectStrategy
          * @return a warning message for {@code dontRestrictJobConfiguration} if it is {@code true}
          * @see SpecificUsersAuthorizationStrategy#setDontRestrictJobConfiguration(boolean)
          */
-        public FormValidation doCheckDontRestrictJobConfiguration(@QueryParameter boolean dontRestrictJobConfiguration) {
+        public FormValidation doCheckDontRestrictJobConfiguration(
+                @QueryParameter boolean dontRestrictJobConfiguration) {
             if (dontRestrictJobConfiguration) {
-                return FormValidation.warning(Messages.SpecificUsersAuthorizationStrategy_dontRestrictJobConfiguration_usage());
+                return FormValidation.warning(
+                        Messages.SpecificUsersAuthorizationStrategy_dontRestrictJobConfiguration_usage());
             }
             return FormValidation.ok();
         }
@@ -373,7 +373,7 @@ public class SpecificUsersAuthorizationStrategy extends AuthorizeProjectStrategy
         public boolean isUseApitoken() {
             return !(Jenkins.get().getSecurityRealm() instanceof AbstractPasswordBasedSecurityRealm);
         }
-        
+
         /**
          * {@link SpecificUsersAuthorizationStrategy} should be disabled by default for JENKINS-28298
          * @return false

--- a/src/main/java/org/jenkinsci/plugins/authorizeproject/strategy/SystemAuthorizationStrategy.java
+++ b/src/main/java/org/jenkinsci/plugins/authorizeproject/strategy/SystemAuthorizationStrategy.java
@@ -1,18 +1,18 @@
 /*
  * The MIT License
- * 
+ *
  * Copyright (c) 2013-2016 Stephen Connolly, IKEDA Yasuyuki
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -184,8 +184,7 @@ public class SystemAuthorizationStrategy extends AuthorizeProjectStrategy {
          * {@inheritDoc}
          */
         @Override
-        public SystemAuthorizationStrategy newInstance(StaplerRequest req, JSONObject formData)
-                throws FormException {
+        public SystemAuthorizationStrategy newInstance(StaplerRequest req, JSONObject formData) throws FormException {
             SystemAuthorizationStrategy result = (SystemAuthorizationStrategy) super.newInstance(req, formData);
             Jenkins instance = Jenkins.get();
             if (!instance.hasPermission(Jenkins.RUN_SCRIPTS)) {

--- a/src/main/java/org/jenkinsci/plugins/authorizeproject/strategy/TriggeringUsersAuthorizationStrategy.java
+++ b/src/main/java/org/jenkinsci/plugins/authorizeproject/strategy/TriggeringUsersAuthorizationStrategy.java
@@ -1,18 +1,18 @@
 /*
  * The MIT License
- * 
+ *
  * Copyright (c) 2013 IKEDA Yasuyuki
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -24,21 +24,20 @@
 
 package org.jenkinsci.plugins.authorizeproject.strategy;
 
-import hudson.model.Item;
-import hudson.security.AccessControlled;
-import jenkins.model.Jenkins;
 import hudson.Extension;
 import hudson.model.Cause;
 import hudson.model.Cause.UpstreamCause;
 import hudson.model.Cause.UserIdCause;
+import hudson.model.Item;
 import hudson.model.Job;
 import hudson.model.Queue;
 import hudson.model.Run;
 import hudson.model.User;
+import hudson.security.AccessControlled;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
+import jenkins.model.Jenkins;
 import org.acegisecurity.Authentication;
 import org.acegisecurity.userdetails.UsernameNotFoundException;
 import org.jenkinsci.plugins.authorizeproject.AuthorizeProjectStrategy;
@@ -57,9 +56,8 @@ public class TriggeringUsersAuthorizationStrategy extends AuthorizeProjectStrate
      * Our constructor.
      */
     @DataBoundConstructor
-    public TriggeringUsersAuthorizationStrategy() {
-    }
-    
+    public TriggeringUsersAuthorizationStrategy() {}
+
     /**
      * {@inheritDoc}
      */
@@ -74,40 +72,43 @@ public class TriggeringUsersAuthorizationStrategy extends AuthorizeProjectStrate
             try {
                 return u.impersonate();
             } catch (UsernameNotFoundException e) {
-                LOGGER.log(Level.WARNING, String.format("Invalid User %s. Falls back to anonymous.", cause.getUserId()), e);
+                LOGGER.log(
+                        Level.WARNING,
+                        String.format("Invalid User %s. Falls back to anonymous.", cause.getUserId()),
+                        e);
                 return Jenkins.ANONYMOUS;
             }
         }
         return null;
     }
-    
+
     /**
      * Returns a cause who triggered this build.
      * <p>
      * If this is a downstream build, search upstream builds.
-     * 
+     *
      * @param item the item to query the triggering user of.
      * @return the {@link UserIdCause} or {@code null} if none could be found.
      */
     private UserIdCause getRootUserIdCause(Queue.Item item) {
-        Run<?,?> upstream = null;
-        for (Cause c: item.getCauses()) {
+        Run<?, ?> upstream = null;
+        for (Cause c : item.getCauses()) {
             if (c instanceof UserIdCause) {
-                return (UserIdCause)c;
+                return (UserIdCause) c;
             } else if (c instanceof UpstreamCause) {
-                upstream = ((UpstreamCause)c).getUpstreamRun();
+                upstream = ((UpstreamCause) c).getUpstreamRun();
             }
         }
-        
+
         while (upstream != null) {
             UserIdCause cause = upstream.getCause(UserIdCause.class);
             if (cause != null) {
                 return cause;
             }
             UpstreamCause upstreamCause = upstream.getCause(UpstreamCause.class);
-            upstream = (upstreamCause != null)?upstreamCause.getUpstreamRun():null;
+            upstream = (upstreamCause != null) ? upstreamCause.getUpstreamRun() : null;
         }
-        
+
         return null;
     }
 

--- a/src/test/java/org/jenkinsci/plugins/authorizeproject/ConfigurationAsCodeTest.java
+++ b/src/test/java/org/jenkinsci/plugins/authorizeproject/ConfigurationAsCodeTest.java
@@ -1,9 +1,9 @@
 package org.jenkinsci.plugins.authorizeproject;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 import hudson.util.DescribableList;
 import io.jenkins.plugins.casc.ConfigurationContext;
@@ -26,12 +26,14 @@ import org.jvnet.hudson.test.recipes.LocalData;
 
 public class ConfigurationAsCodeTest {
 
-    @Rule public JenkinsConfiguredWithCodeRule r = new JenkinsConfiguredWithCodeRule();
+    @Rule
+    public JenkinsConfiguredWithCodeRule r = new JenkinsConfiguredWithCodeRule();
 
     @Test
     @ConfiguredWithCode("ConfigurationAsCodeTest/global.config.AnonymousAuthorizationStrategy.yml")
     public void importGlobalAnonymousAuthorizationStrategy() {
-        DescribableList<QueueItemAuthenticator, QueueItemAuthenticatorDescriptor> authenticators = QueueItemAuthenticatorConfiguration.get().getAuthenticators();
+        DescribableList<QueueItemAuthenticator, QueueItemAuthenticatorDescriptor> authenticators =
+                QueueItemAuthenticatorConfiguration.get().getAuthenticators();
         GlobalQueueItemAuthenticator queueItemAuthenticator = authenticators.get(GlobalQueueItemAuthenticator.class);
 
         assertThat(authenticators, hasSize(1));
@@ -47,12 +49,15 @@ public class ConfigurationAsCodeTest {
     @Test
     @ConfiguredWithCode("ConfigurationAsCodeTest/global.config.SpecificUsersAuthorizationStrategy.yml")
     public void importGlobalSpecificUsersAuthorizationStrategy() {
-        DescribableList<QueueItemAuthenticator, QueueItemAuthenticatorDescriptor> authenticators = QueueItemAuthenticatorConfiguration.get().getAuthenticators();
+        DescribableList<QueueItemAuthenticator, QueueItemAuthenticatorDescriptor> authenticators =
+                QueueItemAuthenticatorConfiguration.get().getAuthenticators();
         GlobalQueueItemAuthenticator queueItemAuthenticator = authenticators.get(GlobalQueueItemAuthenticator.class);
 
         assertThat(authenticators, hasSize(1));
         assertThat(queueItemAuthenticator.getStrategy(), instanceOf(SpecificUsersAuthorizationStrategy.class));
-        assertThat(((SpecificUsersAuthorizationStrategy) queueItemAuthenticator.getStrategy()).getUserid(), equalTo("some-user"));
+        assertThat(
+                ((SpecificUsersAuthorizationStrategy) queueItemAuthenticator.getStrategy()).getUserid(),
+                equalTo("some-user"));
     }
 
     @Test
@@ -64,7 +69,8 @@ public class ConfigurationAsCodeTest {
     @Test
     @ConfiguredWithCode("ConfigurationAsCodeTest/global.config.SystemAuthorizationStrategy.yml")
     public void importGlobalSystemAuthorizationStrategy() {
-        DescribableList<QueueItemAuthenticator, QueueItemAuthenticatorDescriptor> authenticators = QueueItemAuthenticatorConfiguration.get().getAuthenticators();
+        DescribableList<QueueItemAuthenticator, QueueItemAuthenticatorDescriptor> authenticators =
+                QueueItemAuthenticatorConfiguration.get().getAuthenticators();
         GlobalQueueItemAuthenticator queueItemAuthenticator = authenticators.get(GlobalQueueItemAuthenticator.class);
 
         assertThat(authenticators, hasSize(1));
@@ -80,7 +86,8 @@ public class ConfigurationAsCodeTest {
     @Test
     @ConfiguredWithCode("ConfigurationAsCodeTest/global.config.TriggeringUsersAuthorizationStrategy.yml")
     public void importGlobalTriggeringUsersAuthorizationStrategy() {
-        DescribableList<QueueItemAuthenticator, QueueItemAuthenticatorDescriptor> authenticators = QueueItemAuthenticatorConfiguration.get().getAuthenticators();
+        DescribableList<QueueItemAuthenticator, QueueItemAuthenticatorDescriptor> authenticators =
+                QueueItemAuthenticatorConfiguration.get().getAuthenticators();
         GlobalQueueItemAuthenticator queueItemAuthenticator = authenticators.get(GlobalQueueItemAuthenticator.class);
 
         assertThat(authenticators, hasSize(1));
@@ -96,12 +103,20 @@ public class ConfigurationAsCodeTest {
     @Test
     @ConfiguredWithCode("ConfigurationAsCodeTest/project.config.all.yml")
     public void importProjectTriggeringUsersAuthorizationStrategy() {
-        DescribableList<QueueItemAuthenticator, QueueItemAuthenticatorDescriptor> authenticators = QueueItemAuthenticatorConfiguration.get().getAuthenticators();
+        DescribableList<QueueItemAuthenticator, QueueItemAuthenticatorDescriptor> authenticators =
+                QueueItemAuthenticatorConfiguration.get().getAuthenticators();
         ProjectQueueItemAuthenticator queueItemAuthenticator = authenticators.get(ProjectQueueItemAuthenticator.class);
 
         assertThat(authenticators, hasSize(1));
-        assertThat(queueItemAuthenticator.getDisabledStrategies(), equalTo(Set.of(SystemAuthorizationStrategy.class.getName(), SpecificUsersAuthorizationStrategy.class.getName(), TriggeringUsersAuthorizationStrategy.class.getName())));
-        assertThat(queueItemAuthenticator.getEnabledStrategies(), equalTo(Set.of(AnonymousAuthorizationStrategy.class.getName())));
+        assertThat(
+                queueItemAuthenticator.getDisabledStrategies(),
+                equalTo(Set.of(
+                        SystemAuthorizationStrategy.class.getName(),
+                        SpecificUsersAuthorizationStrategy.class.getName(),
+                        TriggeringUsersAuthorizationStrategy.class.getName())));
+        assertThat(
+                queueItemAuthenticator.getEnabledStrategies(),
+                equalTo(Set.of(AnonymousAuthorizationStrategy.class.getName())));
     }
 
     @Test
@@ -124,11 +139,20 @@ public class ConfigurationAsCodeTest {
     @LocalData
     @Test
     public void strategyEnabledMapMigration() {
-        DescribableList<QueueItemAuthenticator, QueueItemAuthenticatorDescriptor> authenticators = QueueItemAuthenticatorConfiguration.get().getAuthenticators();
+        DescribableList<QueueItemAuthenticator, QueueItemAuthenticatorDescriptor> authenticators =
+                QueueItemAuthenticatorConfiguration.get().getAuthenticators();
         ProjectQueueItemAuthenticator queueItemAuthenticator = authenticators.get(ProjectQueueItemAuthenticator.class);
 
         assertThat(authenticators, hasSize(1));
-        assertThat(queueItemAuthenticator.getDisabledStrategies(), equalTo(Set.of(SpecificUsersAuthorizationStrategy.class.getName(), SystemAuthorizationStrategy.class.getName())));
-        assertThat(queueItemAuthenticator.getEnabledStrategies(), equalTo(Set.of(AnonymousAuthorizationStrategy.class.getName(), TriggeringUsersAuthorizationStrategy.class.getName())));
+        assertThat(
+                queueItemAuthenticator.getDisabledStrategies(),
+                equalTo(Set.of(
+                        SpecificUsersAuthorizationStrategy.class.getName(),
+                        SystemAuthorizationStrategy.class.getName())));
+        assertThat(
+                queueItemAuthenticator.getEnabledStrategies(),
+                equalTo(Set.of(
+                        AnonymousAuthorizationStrategy.class.getName(),
+                        TriggeringUsersAuthorizationStrategy.class.getName())));
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/authorizeproject/GlobalQueueItemAuthenticatorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/authorizeproject/GlobalQueueItemAuthenticatorTest.java
@@ -1,5 +1,8 @@
 package org.jenkinsci.plugins.authorizeproject;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 import hudson.model.FreeStyleProject;
 import hudson.model.User;
 import hudson.security.ACL;
@@ -17,13 +20,9 @@ import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.JenkinsRule.WebClient;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
 public class GlobalQueueItemAuthenticatorTest {
     @Rule
     public JenkinsRule j = new AuthorizeProjectJenkinsRule();
-
 
     @Test
     public void testWorkForFreeStyleProject() throws Exception {
@@ -43,8 +42,7 @@ public class GlobalQueueItemAuthenticatorTest {
         }
 
         authenticators.add(new GlobalQueueItemAuthenticator(
-                new SpecificUsersAuthorizationStrategy(User.getById("bob", true).getId()))
-        );
+                new SpecificUsersAuthorizationStrategy(User.getById("bob", true).getId())));
         // if configured, GlobalQueueItemAuthenticator takes effect
         {
             FreeStyleProject p = j.createFreeStyleProject();
@@ -84,33 +82,29 @@ public class GlobalQueueItemAuthenticatorTest {
             assertEquals("bob", checker.authentication.getPrincipal());
         }
     }
-    
+
     @Test
     public void testConfiguration() throws Exception {
-        GlobalQueueItemAuthenticator auth = new GlobalQueueItemAuthenticator(
-                new AnonymousAuthorizationStrategy()
-        );
+        GlobalQueueItemAuthenticator auth = new GlobalQueueItemAuthenticator(new AnonymousAuthorizationStrategy());
         QueueItemAuthenticatorConfiguration.get().getAuthenticators().add(auth);
-        
+
         WebClient wc = j.createWebClient();
         j.submit(wc.goTo("configureSecurity").getFormByName("config"));
-        
+
         j.assertEqualDataBoundBeans(
                 auth,
-                QueueItemAuthenticatorConfiguration.get().getAuthenticators().get(GlobalQueueItemAuthenticator.class)
-        );
+                QueueItemAuthenticatorConfiguration.get().getAuthenticators().get(GlobalQueueItemAuthenticator.class));
     }
-    
+
     @Test
     public void testConfigurationWithDescriptorNewInstance() throws Exception {
-        GlobalQueueItemAuthenticator auth = new GlobalQueueItemAuthenticator(
-                new SpecificUsersAuthorizationStrategy("admin")
-        );
+        GlobalQueueItemAuthenticator auth =
+                new GlobalQueueItemAuthenticator(new SpecificUsersAuthorizationStrategy("admin"));
         QueueItemAuthenticatorConfiguration.get().getAuthenticators().add(auth);
-        
+
         WebClient wc = j.createWebClient();
         j.submit(wc.goTo("configureSecurity").getFormByName("config"));
-        
+
         /*
         // as SpecificUsersAuthorizationStrategy is not annotated with @DataBoundConstructor,
         // assertEqualDataBoundBeans is not applicable.
@@ -119,12 +113,12 @@ public class GlobalQueueItemAuthenticatorTest {
                 QueueItemAuthenticatorConfiguration.get().getAuthenticators().get(GlobalQueueItemAuthenticator.class)
         );
         */
-        AuthorizeProjectStrategy strategy = QueueItemAuthenticatorConfiguration.get().getAuthenticators().get(GlobalQueueItemAuthenticator.class).getStrategy();
+        AuthorizeProjectStrategy strategy = QueueItemAuthenticatorConfiguration.get()
+                .getAuthenticators()
+                .get(GlobalQueueItemAuthenticator.class)
+                .getStrategy();
         assertEquals(SpecificUsersAuthorizationStrategy.class, strategy.getClass());
-        assertEquals(
-                "admin",
-                ((SpecificUsersAuthorizationStrategy)strategy).getUserid()
-        );
+        assertEquals("admin", ((SpecificUsersAuthorizationStrategy) strategy).getUserid());
         // Don't care about noNeedReauthentication
         // (It might be removed for GlobalQueueItemAuthenticator in future)
     }

--- a/src/test/java/org/jenkinsci/plugins/authorizeproject/ProjectQueueItemAuthenticatorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/authorizeproject/ProjectQueueItemAuthenticatorTest.java
@@ -1,18 +1,18 @@
 /*
  * The MIT License
- * 
+ *
  * Copyright (c) 2013 IKEDA Yasuyuki
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -26,11 +26,11 @@ package org.jenkinsci.plugins.authorizeproject;
 
 import static org.junit.Assert.*;
 
-import java.util.HashSet;
-import java.util.Set;
-
-import jenkins.model.Jenkins;
-import jenkins.security.QueueItemAuthenticatorConfiguration;
+import com.gargoylesoftware.htmlunit.html.HtmlForm;
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
+import com.gargoylesoftware.htmlunit.html.HtmlTextInput;
+import hudson.FilePath;
+import hudson.Launcher;
 import hudson.matrix.AxisList;
 import hudson.matrix.MatrixProject;
 import hudson.matrix.TextAxis;
@@ -46,9 +46,13 @@ import hudson.model.User;
 import hudson.security.ACL;
 import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.Builder;
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
+import jenkins.model.Jenkins;
+import jenkins.security.QueueItemAuthenticatorConfiguration;
 import jenkins.tasks.SimpleBuildStep;
 import net.sf.json.JSONObject;
-
 import org.acegisecurity.Authentication;
 import org.jenkinsci.plugins.authorizeproject.strategy.AnonymousAuthorizationStrategy;
 import org.jenkinsci.plugins.authorizeproject.strategy.SpecificUsersAuthorizationStrategy;
@@ -65,28 +69,19 @@ import org.jvnet.hudson.test.TestExtension;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest;
 
-import com.gargoylesoftware.htmlunit.html.HtmlForm;
-import com.gargoylesoftware.htmlunit.html.HtmlPage;
-import com.gargoylesoftware.htmlunit.html.HtmlTextInput;
-
-import java.io.IOException;
-import hudson.FilePath;
-import hudson.Launcher;
-
 public class ProjectQueueItemAuthenticatorTest {
     @Rule
     public JenkinsRule j = new AuthorizeProjectJenkinsRule(SpecificUsersAuthorizationStrategy.class);
-    
+
     public static class NullAuthorizeProjectStrategy extends AuthorizeProjectStrategy {
         @DataBoundConstructor
-        public NullAuthorizeProjectStrategy() {
-        }
-        
+        public NullAuthorizeProjectStrategy() {}
+
         @Override
         public Authentication authenticate(Job<?, ?> project, Queue.Item item) {
             return null;
         }
-        
+
         @TestExtension
         public static class DescriptorImpl extends AuthorizeProjectStrategyDescriptor {
             @Override
@@ -95,7 +90,7 @@ public class ProjectQueueItemAuthenticatorTest {
             }
         }
     }
-    
+
     @Test
     public void testWorkForFreeStyleProject() throws Exception {
         // if not configured, run in SYSTEM privilege.
@@ -103,48 +98,48 @@ public class ProjectQueueItemAuthenticatorTest {
             FreeStyleProject p = j.createFreeStyleProject();
             AuthorizationCheckBuilder checker = new AuthorizationCheckBuilder();
             p.getBuildersList().add(checker);
-            
+
             j.assertBuildStatusSuccess(p.scheduleBuild2(0));
             assertEquals(ACL.SYSTEM, checker.authentication);
         }
-        
+
         // if configured, AuthorizeProjectStrategy takes effect
         {
             FreeStyleProject p = j.createFreeStyleProject();
             AuthorizationCheckBuilder checker = new AuthorizationCheckBuilder();
             p.getBuildersList().add(checker);
-            
+
             p.addProperty(new AuthorizeProjectProperty(new AnonymousAuthorizationStrategy()));
-            
+
             j.assertBuildStatusSuccess(p.scheduleBuild2(0));
             assertEquals(Jenkins.ANONYMOUS, checker.authentication);
         }
-        
+
         // if configured wrong, run in SYSTEM privilege.
         {
             FreeStyleProject p = j.createFreeStyleProject();
             AuthorizationCheckBuilder checker = new AuthorizationCheckBuilder();
             p.getBuildersList().add(checker);
-            
+
             p.addProperty(new AuthorizeProjectProperty(null));
-            
+
             j.assertBuildStatusSuccess(p.scheduleBuild2(0));
             assertEquals(ACL.SYSTEM, checker.authentication);
         }
-        
+
         // if the strategy returns null, run in SYSTEM privilege.
         {
             FreeStyleProject p = j.createFreeStyleProject();
             AuthorizationCheckBuilder checker = new AuthorizationCheckBuilder();
             p.getBuildersList().add(checker);
-            
+
             p.addProperty(new AuthorizeProjectProperty(new NullAuthorizeProjectStrategy()));
-            
+
             j.assertBuildStatusSuccess(p.scheduleBuild2(0));
             assertEquals(ACL.SYSTEM, checker.authentication);
         }
     }
-    
+
     @Test
     public void testWorkForMatrixProject() throws Exception {
         // if not configured, run in SYSTEM privilege.
@@ -153,75 +148,84 @@ public class ProjectQueueItemAuthenticatorTest {
             p.setAxes(new AxisList(new TextAxis("axis1", "value1")));
             AuthorizationCheckBuilder checker = new AuthorizationCheckBuilder();
             p.getBuildersList().add(checker);
-            
+
             j.assertBuildStatusSuccess(p.scheduleBuild2(0));
             assertEquals(ACL.SYSTEM, checker.authentication);
         }
-        
+
         // if configured, AuthorizeProjectStrategy takes effect
         {
             MatrixProject p = j.createProject(MatrixProject.class);
             p.setAxes(new AxisList(new TextAxis("axis1", "value1")));
             AuthorizationCheckBuilder checker = new AuthorizationCheckBuilder();
             p.getBuildersList().add(checker);
-            
+
             p.addProperty(new AuthorizeProjectProperty(new AnonymousAuthorizationStrategy()));
-            
+
             j.assertBuildStatusSuccess(p.scheduleBuild2(0));
             assertEquals(Jenkins.ANONYMOUS, checker.authentication);
         }
-        
+
         // if configured wrong, run in SYSTEM privilege.
         {
             MatrixProject p = j.createProject(MatrixProject.class);
             p.setAxes(new AxisList(new TextAxis("axis1", "value1")));
             AuthorizationCheckBuilder checker = new AuthorizationCheckBuilder();
             p.getBuildersList().add(checker);
-            
+
             p.addProperty(new AuthorizeProjectProperty(null));
-            
+
             j.assertBuildStatusSuccess(p.scheduleBuild2(0));
             assertEquals(ACL.SYSTEM, checker.authentication);
         }
-        
+
         // if the strategy returns null, run in SYSTEM privilege.
         {
             MatrixProject p = j.createProject(MatrixProject.class);
             p.setAxes(new AxisList(new TextAxis("axis1", "value1")));
             AuthorizationCheckBuilder checker = new AuthorizationCheckBuilder();
             p.getBuildersList().add(checker);
-            
+
             p.addProperty(new AuthorizeProjectProperty(new NullAuthorizeProjectStrategy()));
-            
+
             j.assertBuildStatusSuccess(p.scheduleBuild2(0));
             assertEquals(ACL.SYSTEM, checker.authentication);
         }
     }
-    
+
     @Test
     public void testDisabledInProjectAuthorization() throws Exception {
         FreeStyleProject p = j.createFreeStyleProject();
         p.addProperty(new AuthorizeProjectProperty(new AnonymousAuthorizationStrategy()));
 
-        assertTrue(ProjectQueueItemAuthenticator.getConfigured().isStrategyEnabled(j.jenkins.getDescriptor(AnonymousAuthorizationStrategy.class)));
+        assertTrue(ProjectQueueItemAuthenticator.getConfigured()
+                .isStrategyEnabled(j.jenkins.getDescriptor(AnonymousAuthorizationStrategy.class)));
 
         j.submit(j.createWebClient().getPage(p, "authorization").getFormByName("config"));
 
         // can be reconfigured if it is enabled.
-        assertEquals(AnonymousAuthorizationStrategy.class, p.getProperty(AuthorizeProjectProperty.class).getStrategy().getClass());
+        assertEquals(
+                AnonymousAuthorizationStrategy.class,
+                p.getProperty(AuthorizeProjectProperty.class).getStrategy().getClass());
 
         Set<String> enabledStrategies = Set.of();
-        Set<String> disabledStrategies = Set.of(j.jenkins.getDescriptor(AnonymousAuthorizationStrategy.class).getId());
+        Set<String> disabledStrategies = Set.of(
+                j.jenkins.getDescriptor(AnonymousAuthorizationStrategy.class).getId());
 
         QueueItemAuthenticatorConfiguration.get().getAuthenticators().clear();
-        QueueItemAuthenticatorConfiguration.get().getAuthenticators().add(new ProjectQueueItemAuthenticator(enabledStrategies, disabledStrategies));
+        QueueItemAuthenticatorConfiguration.get()
+                .getAuthenticators()
+                .add(new ProjectQueueItemAuthenticator(enabledStrategies, disabledStrategies));
 
-        assertFalse(ProjectQueueItemAuthenticator.getConfigured().isStrategyEnabled(j.jenkins.getDescriptor(AnonymousAuthorizationStrategy.class)));
+        assertFalse(ProjectQueueItemAuthenticator.getConfigured()
+                .isStrategyEnabled(j.jenkins.getDescriptor(AnonymousAuthorizationStrategy.class)));
 
         j.submit(j.createWebClient().getPage(p, "authorization").getFormByName("config"));
 
         // cannot be reconfigured if it is disabled.
-        assertNotEquals(AnonymousAuthorizationStrategy.class, p.getProperty(AuthorizeProjectProperty.class).getStrategy().getClass());
+        assertNotEquals(
+                AnonymousAuthorizationStrategy.class,
+                p.getProperty(AuthorizeProjectProperty.class).getStrategy().getClass());
     }
 
     @Test
@@ -230,195 +234,198 @@ public class ProjectQueueItemAuthenticatorTest {
         AuthorizationCheckBuilder checker = new AuthorizationCheckBuilder();
         p.getBuildersList().add(checker);
         p.addProperty(new AuthorizeProjectProperty(new AnonymousAuthorizationStrategy()));
-        
-        assertTrue(ProjectQueueItemAuthenticator.getConfigured().isStrategyEnabled(j.jenkins.getDescriptor(AnonymousAuthorizationStrategy.class)));
-        
+
+        assertTrue(ProjectQueueItemAuthenticator.getConfigured()
+                .isStrategyEnabled(j.jenkins.getDescriptor(AnonymousAuthorizationStrategy.class)));
+
         // strategy works if it is enabled
         j.assertBuildStatusSuccess(p.scheduleBuild2(0));
         assertEquals(Jenkins.ANONYMOUS, checker.authentication);
-        
+
         Set<String> enabledStrategies = Set.of();
-        Set<String> disabledStrategies = Set.of(j.jenkins.getDescriptor(AnonymousAuthorizationStrategy.class).getId());
-        
+        Set<String> disabledStrategies = Set.of(
+                j.jenkins.getDescriptor(AnonymousAuthorizationStrategy.class).getId());
+
         QueueItemAuthenticatorConfiguration.get().getAuthenticators().clear();
-        QueueItemAuthenticatorConfiguration.get().getAuthenticators().add(new ProjectQueueItemAuthenticator(enabledStrategies, disabledStrategies));
-        
-        assertFalse(ProjectQueueItemAuthenticator.getConfigured().isStrategyEnabled(j.jenkins.getDescriptor(AnonymousAuthorizationStrategy.class)));
-        
+        QueueItemAuthenticatorConfiguration.get()
+                .getAuthenticators()
+                .add(new ProjectQueueItemAuthenticator(enabledStrategies, disabledStrategies));
+
+        assertFalse(ProjectQueueItemAuthenticator.getConfigured()
+                .isStrategyEnabled(j.jenkins.getDescriptor(AnonymousAuthorizationStrategy.class)));
+
         // strategy doesn't work if it is disabled even when it is configured
         j.assertBuildStatusSuccess(p.scheduleBuild2(0));
         assertEquals(ACL.SYSTEM, checker.authentication);
     }
-    
+
     /**
      * Test no exception even if no global-security.jelly is not provided.
      */
     public static class AuthorizeProjectStrategyWithoutGlobalSecurityConfiguration extends AuthorizeProjectStrategy {
         @DataBoundConstructor
-        public AuthorizeProjectStrategyWithoutGlobalSecurityConfiguration() {
-        }
+        public AuthorizeProjectStrategyWithoutGlobalSecurityConfiguration() {}
 
         @Override
         public Authentication authenticate(Job<?, ?> project, Queue.Item item) {
             return null;
         }
-        
+
         @TestExtension("testGlobalSecurityConfiguration")
         public static class DescriptorImpl extends AuthorizeProjectStrategyDescriptor {
             @Override
             public String getDisplayName() {
                 return "AuthorizeProjectStrategyWithoutGlobalSecurityConfiguration";
             }
-            
+
             @Override
-            public void configureFromGlobalSecurity(StaplerRequest req, JSONObject js)
-                    throws Descriptor.FormException
-            {
+            public void configureFromGlobalSecurity(StaplerRequest req, JSONObject js) throws Descriptor.FormException {
                 throw new FormException("Should not be called for global-security.jelly is not defined.", "");
             }
         }
     }
-    
+
     /**
      * Test configuration in "Configure Global Security" is available.
      */
     public static class AuthorizeProjectStrategyWithGlobalSecurityConfiguration extends AuthorizeProjectStrategy {
         @DataBoundConstructor
-        public AuthorizeProjectStrategyWithGlobalSecurityConfiguration() {
-        }
+        public AuthorizeProjectStrategyWithGlobalSecurityConfiguration() {}
 
         @Override
         public Authentication authenticate(Job<?, ?> project, Queue.Item item) {
             return null;
         }
-        
+
         @TestExtension("testGlobalSecurityConfiguration")
         public static class DescriptorImpl extends AuthorizeProjectStrategyDescriptor {
             private String value;
-            
+
             public String getValue() {
                 return value;
             }
-            
+
             public DescriptorImpl() {
                 load();
             }
-            
+
             @Override
             public String getDisplayName() {
                 return "AuthorizeProjectStrategyWithGlobalSecurityConfiguration";
             }
-            
+
             @Override
-            public void configureFromGlobalSecurity(StaplerRequest req, JSONObject js)
-                    throws Descriptor.FormException
-            {
+            public void configureFromGlobalSecurity(StaplerRequest req, JSONObject js) throws Descriptor.FormException {
                 value = js.getString("value");
                 save();
             }
         }
     }
-    
+
     /**
      * Test alternate file except global-security.jelly can be used.
      */
-    public static class AuthorizeProjectStrategyWithAlternateGlobalSecurityConfiguration extends AuthorizeProjectStrategy {
+    public static class AuthorizeProjectStrategyWithAlternateGlobalSecurityConfiguration
+            extends AuthorizeProjectStrategy {
         @DataBoundConstructor
-        public AuthorizeProjectStrategyWithAlternateGlobalSecurityConfiguration() {
-        }
+        public AuthorizeProjectStrategyWithAlternateGlobalSecurityConfiguration() {}
 
         @Override
         public Authentication authenticate(Job<?, ?> project, Queue.Item item) {
             return null;
         }
-        
+
         @TestExtension("testGlobalSecurityConfiguration")
         public static class DescriptorImpl extends AuthorizeProjectStrategyDescriptor {
             private String value;
-            
+
             public String getValue() {
                 return value;
             }
-            
+
             public DescriptorImpl() {
                 load();
             }
-            
+
             @Override
             public String getDisplayName() {
                 return "AuthorizeProjectStrategyWithAlternateGlobalSecurityConfiguration";
             }
-            
+
             @Override
-            public void configureFromGlobalSecurity(StaplerRequest req, JSONObject js)
-                    throws Descriptor.FormException
-            {
+            public void configureFromGlobalSecurity(StaplerRequest req, JSONObject js) throws Descriptor.FormException {
                 value = js.getString("value");
                 save();
             }
-            
+
             @Override
             public String getGlobalSecurityConfigPage() {
                 return getViewPage(clazz, "alternate.jelly");
             }
         }
     }
-    
+
     @Test
     public void testGlobalSecurityConfiguration() throws Exception {
-        AuthorizeProjectStrategyWithGlobalSecurityConfiguration.DescriptorImpl descriptor
-            = (AuthorizeProjectStrategyWithGlobalSecurityConfiguration.DescriptorImpl)Jenkins.get().getDescriptor(AuthorizeProjectStrategyWithGlobalSecurityConfiguration.class);
-        AuthorizeProjectStrategyWithAlternateGlobalSecurityConfiguration.DescriptorImpl alternateDescriptor
-            = (AuthorizeProjectStrategyWithAlternateGlobalSecurityConfiguration.DescriptorImpl)Jenkins.get().getDescriptor(AuthorizeProjectStrategyWithAlternateGlobalSecurityConfiguration.class);
-        
+        AuthorizeProjectStrategyWithGlobalSecurityConfiguration.DescriptorImpl descriptor =
+                (AuthorizeProjectStrategyWithGlobalSecurityConfiguration.DescriptorImpl)
+                        Jenkins.get().getDescriptor(AuthorizeProjectStrategyWithGlobalSecurityConfiguration.class);
+        AuthorizeProjectStrategyWithAlternateGlobalSecurityConfiguration.DescriptorImpl alternateDescriptor =
+                (AuthorizeProjectStrategyWithAlternateGlobalSecurityConfiguration.DescriptorImpl) Jenkins.get()
+                        .getDescriptor(AuthorizeProjectStrategyWithAlternateGlobalSecurityConfiguration.class);
+
         final String value1 = "value1 for AuthorizeProjectStrategyWithGlobalSecurityConfigurationValueField";
         final String alternateValue1 = "value1 for AuthorizeProjectStrategyWithAlternateGlobalSecurityConfiguration";
-        
+
         WebClient wc = j.createWebClient();
-        
+
         // access to Configure Global Security.
         {
             assertNull(descriptor.getValue());
             assertNull(alternateDescriptor.getValue());
-            
+
             HtmlPage page = wc.goTo("configureSecurity");
             HtmlForm form = page.getFormByName("config");
-            
+
             // verify global-security.jelly is displayed
-            HtmlTextInput valueField = form.getFirstByXPath("//input[@id='AuthorizeProjectStrategyWithGlobalSecurityConfigurationValueField']");
+            HtmlTextInput valueField = form.getFirstByXPath(
+                    "//input[@id='AuthorizeProjectStrategyWithGlobalSecurityConfigurationValueField']");
             assertNotNull(valueField);
             assertEquals("", valueField.getValueAttribute());
-            
+
             // verify alternate.jelly is displayed
-            HtmlTextInput alternateField = form.getFirstByXPath("//input[@id='AuthorizeProjectStrategyWithAlternateGlobalSecurityConfiguration']");
+            HtmlTextInput alternateField = form.getFirstByXPath(
+                    "//input[@id='AuthorizeProjectStrategyWithAlternateGlobalSecurityConfiguration']");
             assertNotNull(alternateField);
             assertEquals("", alternateField.getValueAttribute());
-            
+
             valueField.setValueAttribute(value1);
             alternateField.setValueAttribute(alternateValue1);
-            
+
             j.submit(form);
-            
+
             assertEquals(value1, descriptor.getValue());
             assertEquals(alternateValue1, alternateDescriptor.getValue());
         }
-        
+
         // field is displayed again
         {
             HtmlPage page = wc.goTo("configureSecurity");
             HtmlForm form = page.getFormByName("config");
-            
+
             // verify global-security.jelly is displayed
-            HtmlTextInput valueField = form.getFirstByXPath("//input[@id='AuthorizeProjectStrategyWithGlobalSecurityConfigurationValueField']");
+            HtmlTextInput valueField = form.getFirstByXPath(
+                    "//input[@id='AuthorizeProjectStrategyWithGlobalSecurityConfigurationValueField']");
             assertNotNull(valueField);
             assertEquals(value1, valueField.getValueAttribute());
-            
+
             // verify alternate.jelly is displayed
-            HtmlTextInput alternateField = form.getFirstByXPath("//input[@id='AuthorizeProjectStrategyWithAlternateGlobalSecurityConfiguration']");
+            HtmlTextInput alternateField = form.getFirstByXPath(
+                    "//input[@id='AuthorizeProjectStrategyWithAlternateGlobalSecurityConfiguration']");
             assertNotNull(alternateField);
             assertEquals(alternateValue1, alternateField.getValueAttribute());
         }
-        
+
         // enabled / disabled preservation
         Set<String> enabledStrategies;
         Set<String> disabledStrategies;
@@ -426,50 +433,67 @@ public class ProjectQueueItemAuthenticatorTest {
         // all are enabled
         enabledStrategies = new HashSet<>();
         disabledStrategies = new HashSet<>();
-        enabledStrategies.add(j.jenkins.getDescriptor(AuthorizeProjectStrategyWithoutGlobalSecurityConfiguration.class).getId());
-        enabledStrategies.add(j.jenkins.getDescriptor(AuthorizeProjectStrategyWithGlobalSecurityConfiguration.class).getId());
-        enabledStrategies.add(j.jenkins.getDescriptor(AuthorizeProjectStrategyWithAlternateGlobalSecurityConfiguration.class).getId());
+        enabledStrategies.add(j.jenkins
+                .getDescriptor(AuthorizeProjectStrategyWithoutGlobalSecurityConfiguration.class)
+                .getId());
+        enabledStrategies.add(j.jenkins
+                .getDescriptor(AuthorizeProjectStrategyWithGlobalSecurityConfiguration.class)
+                .getId());
+        enabledStrategies.add(j.jenkins
+                .getDescriptor(AuthorizeProjectStrategyWithAlternateGlobalSecurityConfiguration.class)
+                .getId());
         assertStrategyEnablingConfigurationPreserved(enabledStrategies, disabledStrategies);
-        
+
         // all are disabled
         enabledStrategies = new HashSet<>();
         disabledStrategies = new HashSet<>();
-        disabledStrategies.add(j.jenkins.getDescriptor(AuthorizeProjectStrategyWithoutGlobalSecurityConfiguration.class).getId());
-        disabledStrategies.add(j.jenkins.getDescriptor(AuthorizeProjectStrategyWithGlobalSecurityConfiguration.class).getId());
-        disabledStrategies.add(j.jenkins.getDescriptor(AuthorizeProjectStrategyWithAlternateGlobalSecurityConfiguration.class).getId());
+        disabledStrategies.add(j.jenkins
+                .getDescriptor(AuthorizeProjectStrategyWithoutGlobalSecurityConfiguration.class)
+                .getId());
+        disabledStrategies.add(j.jenkins
+                .getDescriptor(AuthorizeProjectStrategyWithGlobalSecurityConfiguration.class)
+                .getId());
+        disabledStrategies.add(j.jenkins
+                .getDescriptor(AuthorizeProjectStrategyWithAlternateGlobalSecurityConfiguration.class)
+                .getId());
         assertStrategyEnablingConfigurationPreserved(enabledStrategies, disabledStrategies);
-        
+
         // mixed
         enabledStrategies = new HashSet<>();
         disabledStrategies = new HashSet<>();
-        disabledStrategies.add(j.jenkins.getDescriptor(AuthorizeProjectStrategyWithoutGlobalSecurityConfiguration.class).getId());
-        enabledStrategies.add(j.jenkins.getDescriptor(AuthorizeProjectStrategyWithGlobalSecurityConfiguration.class).getId());
-        disabledStrategies.add(j.jenkins.getDescriptor(AuthorizeProjectStrategyWithAlternateGlobalSecurityConfiguration.class).getId());
+        disabledStrategies.add(j.jenkins
+                .getDescriptor(AuthorizeProjectStrategyWithoutGlobalSecurityConfiguration.class)
+                .getId());
+        enabledStrategies.add(j.jenkins
+                .getDescriptor(AuthorizeProjectStrategyWithGlobalSecurityConfiguration.class)
+                .getId());
+        disabledStrategies.add(j.jenkins
+                .getDescriptor(AuthorizeProjectStrategyWithAlternateGlobalSecurityConfiguration.class)
+                .getId());
         assertStrategyEnablingConfigurationPreserved(enabledStrategies, disabledStrategies);
     }
-    
-    public void assertStrategyEnablingConfigurationPreserved(Set<String> enabledStrategies, Set<String> disabledStrategies) throws Exception {
+
+    public void assertStrategyEnablingConfigurationPreserved(
+            Set<String> enabledStrategies, Set<String> disabledStrategies) throws Exception {
         QueueItemAuthenticatorConfiguration.get().getAuthenticators().clear();
-        QueueItemAuthenticatorConfiguration.get().getAuthenticators().add(new ProjectQueueItemAuthenticator(enabledStrategies, disabledStrategies));
+        QueueItemAuthenticatorConfiguration.get()
+                .getAuthenticators()
+                .add(new ProjectQueueItemAuthenticator(enabledStrategies, disabledStrategies));
         j.submit(j.createWebClient().goTo("configureSecurity").getFormByName("config"));
         for (String enabledStrategy : enabledStrategies) {
             assertTrue(
                     enabledStrategy,
-                    ProjectQueueItemAuthenticator.getConfigured().isStrategyEnabled(
-                            j.jenkins.getDescriptor(enabledStrategy)
-                    )
-            );
+                    ProjectQueueItemAuthenticator.getConfigured()
+                            .isStrategyEnabled(j.jenkins.getDescriptor(enabledStrategy)));
         }
         for (String disabledStrategy : disabledStrategies) {
             assertFalse(
                     disabledStrategy,
-                    ProjectQueueItemAuthenticator.getConfigured().isStrategyEnabled(
-                            j.jenkins.getDescriptor(disabledStrategy)
-                    )
-            );
+                    ProjectQueueItemAuthenticator.getConfigured()
+                            .isStrategyEnabled(j.jenkins.getDescriptor(disabledStrategy)));
         }
     }
-    
+
     /**
      * Test alternate file except global-security.jelly can be used.
      */
@@ -480,22 +504,21 @@ public class ProjectQueueItemAuthenticatorTest {
         public AuthorizeProjectStrategyWithOldSignature(String name) {
             this.name = name;
         }
-        
+
         @Override
         public Authentication authenticate(AbstractProject<?, ?> project, Queue.Item item) {
             return User.getById(name, true).impersonate();
         }
-        
+
         @TestExtension
         public static class DescriptorImpl extends AuthorizeProjectStrategyDescriptor {
             @Override
             public String getDisplayName() {
                 return "AuthorizeProjectStrategyWithOldSignature";
             }
-            
         }
     }
-    
+
     @Test
     public void testOldSignature() throws Exception {
         j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
@@ -503,57 +526,58 @@ public class ProjectQueueItemAuthenticatorTest {
         p.addProperty(new AuthorizeProjectProperty(new AuthorizeProjectStrategyWithOldSignature("test1")));
         AuthorizationCheckBuilder checker = new AuthorizationCheckBuilder();
         p.getBuildersList().add(checker);
-        
+
         j.assertBuildStatusSuccess(p.scheduleBuild2(0));
         assertEquals("test1", checker.authentication.getName());
     }
-    
+
     public static class AuthorizationRecordAction extends InvisibleAction {
         // transient because the UsernamePasswordAuthenticationToken is forbidden to be serialized by JEP-200
         public final transient Authentication authentication;
-        
+
         public AuthorizationRecordAction(Authentication authentication) {
             this.authentication = authentication;
         }
     }
-    
+
     public static class AuthorizationCheckSimpleBuilder extends Builder implements SimpleBuildStep {
         @DataBoundConstructor
-        public AuthorizationCheckSimpleBuilder() {
-        }
-        
+        public AuthorizationCheckSimpleBuilder() {}
+
         @Override
         public void perform(Run<?, ?> run, FilePath workspace, Launcher launcher, TaskListener listener)
                 throws InterruptedException, IOException {
             run.addAction(new AuthorizationRecordAction(Jenkins.getAuthentication()));
         }
-        
+
         @TestExtension("testWorkflow")
         public static class DescriptorImpl extends BuildStepDescriptor<Builder> {
             @Override
             public boolean isApplicable(Class<? extends AbstractProject> jobType) {
                 return true;
             }
-            
+
             @Override
             public String getDisplayName() {
                 return "AuthorizationCheckSimpleBuilder";
             }
         }
     }
-    
+
     @Test
     public void testWorkflow() throws Exception {
         j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
         {
-            WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "test"+j.jenkins.getItems().size());
+            WorkflowJob p = j.jenkins.createProject(
+                    WorkflowJob.class, "test" + j.jenkins.getItems().size());
             p.setDefinition(new CpsFlowDefinition("node{ step([$class: 'AuthorizationCheckSimpleBuilder']); }", true));
             WorkflowRun b = p.scheduleBuild2(0).get();
             j.assertBuildStatusSuccess(b);
             assertEquals(ACL.SYSTEM, b.getAction(AuthorizationRecordAction.class).authentication);
         }
         {
-            WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "test"+j.jenkins.getItems().size());
+            WorkflowJob p = j.jenkins.createProject(
+                    WorkflowJob.class, "test" + j.jenkins.getItems().size());
             p.addProperty(new AuthorizeProjectProperty(new AuthorizeProjectStrategyWithOldSignature("test1")));
             p.setDefinition(new CpsFlowDefinition("node{ step([$class: 'AuthorizationCheckSimpleBuilder']); }", true));
             WorkflowRun b = p.scheduleBuild2(0).get();
@@ -561,15 +585,18 @@ public class ProjectQueueItemAuthenticatorTest {
             // Strategies with old signatures don't work for Jobs.
             assertEquals(ACL.SYSTEM, b.getAction(AuthorizationRecordAction.class).authentication);
         }
-        
+
         {
-            WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "test"+j.jenkins.getItems().size());
+            WorkflowJob p = j.jenkins.createProject(
+                    WorkflowJob.class, "test" + j.jenkins.getItems().size());
             p.addProperty(new AuthorizeProjectProperty(new SpecificUsersAuthorizationStrategy("test1")));
-            User.getById("test1", true);  // create
+            User.getById("test1", true); // create
             p.setDefinition(new CpsFlowDefinition("node{ step([$class: 'AuthorizationCheckSimpleBuilder']); }", true));
             WorkflowRun b = p.scheduleBuild2(0).get();
             j.assertBuildStatusSuccess(b);
-            assertEquals(User.getById("test1", false).impersonate(), b.getAction(AuthorizationRecordAction.class).authentication);
+            assertEquals(
+                    User.getById("test1", false).impersonate(),
+                    b.getAction(AuthorizationRecordAction.class).authentication);
         }
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/authorizeproject/strategy/AnonymousAuthorizationStrategyTest.java
+++ b/src/test/java/org/jenkinsci/plugins/authorizeproject/strategy/AnonymousAuthorizationStrategyTest.java
@@ -1,18 +1,18 @@
 /*
  * The MIT License
- * 
+ *
  * Copyright (c) 2013 IKEDA Yasuyuki
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -25,10 +25,10 @@
 package org.jenkinsci.plugins.authorizeproject.strategy;
 
 import static org.junit.Assert.assertEquals;
+
 import hudson.model.FreeStyleProject;
 import hudson.security.ACL;
 import jenkins.model.Jenkins;
-
 import org.jenkinsci.plugins.authorizeproject.AuthorizeProjectProperty;
 import org.jenkinsci.plugins.authorizeproject.testutil.AuthorizationCheckBuilder;
 import org.jenkinsci.plugins.authorizeproject.testutil.AuthorizeProjectJenkinsRule;
@@ -39,21 +39,21 @@ import org.jvnet.hudson.test.JenkinsRule;
 public class AnonymousAuthorizationStrategyTest {
     @Rule
     public JenkinsRule j = new AuthorizeProjectJenkinsRule();
-    
+
     @Test
     public void testAuthenticate() throws Exception {
         FreeStyleProject p = j.createFreeStyleProject();
         AuthorizationCheckBuilder checker = new AuthorizationCheckBuilder();
         p.getBuildersList().add(checker);
-        
+
         // if not configured, run in SYSTEM privilege.
         {
             j.assertBuildStatusSuccess(p.scheduleBuild2(0));
             assertEquals(ACL.SYSTEM, checker.authentication);
         }
-        
+
         p.addProperty(new AuthorizeProjectProperty(new AnonymousAuthorizationStrategy()));
-        
+
         // if configured, run in ANONYMOUS privilege.
         {
             j.assertBuildStatusSuccess(p.scheduleBuild2(0));

--- a/src/test/java/org/jenkinsci/plugins/authorizeproject/strategy/TriggeringUsersAuthorizationStrategyTest.java
+++ b/src/test/java/org/jenkinsci/plugins/authorizeproject/strategy/TriggeringUsersAuthorizationStrategyTest.java
@@ -1,18 +1,18 @@
 /*
  * The MIT License
- * 
+ *
  * Copyright (c) 2013 IKEDA Yasuyuki
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -26,18 +26,16 @@ package org.jenkinsci.plugins.authorizeproject.strategy;
 
 import static org.junit.Assert.*;
 
-import java.util.List;
-import java.util.concurrent.TimeUnit;
-
-import hudson.security.ACLContext;
-import jenkins.model.Jenkins;
-import hudson.model.FreeStyleBuild;
 import hudson.model.Cause;
+import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
 import hudson.model.User;
 import hudson.security.ACL;
+import hudson.security.ACLContext;
 import hudson.tasks.BuildTrigger;
-
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import jenkins.model.Jenkins;
 import org.acegisecurity.providers.UsernamePasswordAuthenticationToken;
 import org.jenkinsci.plugins.authorizeproject.AuthorizeProjectProperty;
 import org.jenkinsci.plugins.authorizeproject.testutil.AuthorizationCheckBuilder;
@@ -52,7 +50,7 @@ import org.jvnet.hudson.test.recipes.LocalData;
 public class TriggeringUsersAuthorizationStrategyTest {
     @Rule
     public JenkinsRule j = new AuthorizeProjectJenkinsRule();
-    
+
     private void triggerBuildWithoutParameters(WebClient wc, FreeStyleProject project) throws Exception {
         // This code may get not to work in future versions of Jenkins.
         // There are several problems:
@@ -61,14 +59,14 @@ public class TriggeringUsersAuthorizationStrategyTest {
         //   (other forms is with <BUTTON>, but this form is with <SUBMIT>.
         j.submit(wc.getPage(project, "build").getFormByName(""));
     }
-    
+
     @Test
     @LocalData
     public void testAuthenticate() throws Exception {
         FreeStyleProject p = j.createFreeStyleProject();
         AuthorizationCheckBuilder checker = new AuthorizationCheckBuilder();
         p.getBuildersList().add(checker);
-        
+
         // if not configured, run in SYSTEM privilege.
         {
             assertNull(p.getLastBuild());
@@ -78,13 +76,13 @@ public class TriggeringUsersAuthorizationStrategyTest {
             FreeStyleBuild b = p.getLastBuild();
             assertNotNull(b);
             j.assertBuildStatusSuccess(b);
-            
+
             assertEquals(ACL.SYSTEM, checker.authentication);
             b.delete();
         }
-        
+
         p.addProperty(new AuthorizeProjectProperty(new TriggeringUsersAuthorizationStrategy()));
-        
+
         // if configured, run in ANONYMOUS privilege.
         {
             assertNull(p.getLastBuild());
@@ -94,11 +92,11 @@ public class TriggeringUsersAuthorizationStrategyTest {
             FreeStyleBuild b = p.getLastBuild();
             assertNotNull(b);
             j.assertBuildStatusSuccess(b);
-            
+
             assertEquals(Jenkins.ANONYMOUS, checker.authentication);
             b.delete();
         }
-        
+
         // if triggered from a user, run in the privilege of that user.
         {
             assertNull(p.getLastBuild());
@@ -108,11 +106,11 @@ public class TriggeringUsersAuthorizationStrategyTest {
             FreeStyleBuild b = p.getLastBuild();
             assertNotNull(b);
             j.assertBuildStatusSuccess(b);
-            
+
             assertEquals("test1", checker.authentication.getName());
             b.delete();
         }
-        
+
         // test with another user.
         {
             assertNull(p.getLastBuild());
@@ -122,12 +120,12 @@ public class TriggeringUsersAuthorizationStrategyTest {
             FreeStyleBuild b = p.getLastBuild();
             assertNotNull(b);
             j.assertBuildStatusSuccess(b);
-            
+
             assertEquals("test2", checker.authentication.getName());
             b.delete();
         }
     }
-    
+
     @Test
     @LocalData
     public void testAuthenticateDownstream() throws Exception {
@@ -135,12 +133,12 @@ public class TriggeringUsersAuthorizationStrategyTest {
         AuthorizationCheckBuilder checker = new AuthorizationCheckBuilder();
         p.getBuildersList().add(checker);
         p.addProperty(new AuthorizeProjectProperty(new TriggeringUsersAuthorizationStrategy()));
-        
+
         FreeStyleProject upstream = j.createFreeStyleProject();
         upstream.getPublishersList().add(new BuildTrigger(p.getFullName(), false));
-        
+
         j.jenkins.rebuildDependencyGraph();
-        
+
         // if triggered from a user, its downstream runs in the privilege of that user.
         {
             assertNull(p.getLastBuild());
@@ -150,40 +148,38 @@ public class TriggeringUsersAuthorizationStrategyTest {
             FreeStyleBuild b = p.getLastBuild();
             assertNotNull(b);
             j.assertBuildStatusSuccess(b);
-            
+
             assertEquals("test1", checker.authentication.getName());
             b.delete();
         }
     }
-    
+
     @Test
     public void testUserNotFoundException() throws Exception {
-        j.jenkins.setSecurityRealm(new SecurityRealmWithUserFilter(
-                j.createDummySecurityRealm(),
-                List.of("validuser")
-        ));
-        
+        j.jenkins.setSecurityRealm(new SecurityRealmWithUserFilter(j.createDummySecurityRealm(), List.of("validuser")));
+
         // Users should be created before the test.
         User.getById("validuser", true);
         User.getById("invaliduser", true);
-        
+
         FreeStyleProject p = j.createFreeStyleProject();
         p.addProperty(new AuthorizeProjectProperty(new TriggeringUsersAuthorizationStrategy()));
         AuthorizationCheckBuilder checker = new AuthorizationCheckBuilder();
         p.getBuildersList().add(checker);
-        
+
         try (ACLContext ignored = ACL.as(new UsernamePasswordAuthenticationToken("validuser", "validuser"))) {
-             j.assertBuildStatusSuccess(p.scheduleBuild2(0, new Cause.UserIdCause()).get(10, TimeUnit.SECONDS));
+            j.assertBuildStatusSuccess(
+                    p.scheduleBuild2(0, new Cause.UserIdCause()).get(10, TimeUnit.SECONDS));
         }
         assertEquals("validuser", checker.authentication.getName());
-        
+
         // In case of specifying an invalid user,
         // falls back to anonymous.
         // And the build should not be blocked.
         try (ACLContext ignored = ACL.as(new UsernamePasswordAuthenticationToken("invaliduser", "invaliduser"))) {
-            j.assertBuildStatusSuccess(p.scheduleBuild2(0, new Cause.UserIdCause()).get(10, TimeUnit.SECONDS));
+            j.assertBuildStatusSuccess(
+                    p.scheduleBuild2(0, new Cause.UserIdCause()).get(10, TimeUnit.SECONDS));
         }
         assertEquals(Jenkins.ANONYMOUS, checker.authentication);
     }
-    
 }

--- a/src/test/java/org/jenkinsci/plugins/authorizeproject/testutil/AuthorizationCheckBuilder.java
+++ b/src/test/java/org/jenkinsci/plugins/authorizeproject/testutil/AuthorizationCheckBuilder.java
@@ -1,18 +1,18 @@
 /*
  * The MIT License
- * 
+ *
  * Copyright (c) 2013 IKEDA Yasuyuki
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -24,44 +24,41 @@
 
 package org.jenkinsci.plugins.authorizeproject.testutil;
 
-import java.io.IOException;
-
-import org.acegisecurity.Authentication;
-
-import jenkins.model.Jenkins;
-
 import hudson.Launcher;
 import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
 import hudson.model.BuildListener;
 import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.Builder;
+import java.io.IOException;
+import jenkins.model.Jenkins;
+import org.acegisecurity.Authentication;
 
 public class AuthorizationCheckBuilder extends Builder {
 
     // "transient" is required for exclusion from serialization - see https://jenkins.io/redirect/class-filter/
     public transient Authentication authentication = null;
-    
+
     @Override
     public boolean prebuild(AbstractBuild<?, ?> build, BuildListener listener) {
         authentication = null;
         return true;
     }
-    
+
     @Override
-    public boolean perform(AbstractBuild<?, ?> build, Launcher launcher,
-            BuildListener listener) throws InterruptedException, IOException {
+    public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener)
+            throws InterruptedException, IOException {
         authentication = Jenkins.getAuthentication();
         return true;
     }
-    
+
     public static class DescriptorImpl extends BuildStepDescriptor<Builder> {
         @SuppressWarnings("rawtypes")
         @Override
         public boolean isApplicable(Class<? extends AbstractProject> jobType) {
             return true;
         }
-        
+
         @Override
         public String getDisplayName() {
             return "AuthorizationCheckBuilder";

--- a/src/test/java/org/jenkinsci/plugins/authorizeproject/testutil/AuthorizeProjectJenkinsRule.java
+++ b/src/test/java/org/jenkinsci/plugins/authorizeproject/testutil/AuthorizeProjectJenkinsRule.java
@@ -1,18 +1,18 @@
 /*
  * The MIT License
- * 
+ *
  * Copyright (c) 2013 IKEDA Yasuyuki
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -24,43 +24,41 @@
 
 package org.jenkinsci.plugins.authorizeproject.testutil;
 
+import com.gargoylesoftware.htmlunit.WebResponse;
 import hudson.model.Describable;
-
 import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
 import jenkins.security.QueueItemAuthenticatorConfiguration;
-
 import org.jenkinsci.plugins.authorizeproject.ProjectQueueItemAuthenticator;
 import org.jvnet.hudson.test.JenkinsRule;
-
-import com.gargoylesoftware.htmlunit.WebResponse;
 
 public class AuthorizeProjectJenkinsRule extends JenkinsRule {
     private Set<Class<? extends Describable<?>>> enabledStrategiesByClass;
     private Set<Class<? extends Describable<?>>> disabledStrategiesByClass;
-    
+
     public AuthorizeProjectJenkinsRule() {
         this(Set.of(), Set.of());
     }
-    
+
     @SafeVarargs
     public AuthorizeProjectJenkinsRule(Class<? extends Describable<?>>... enabledStrategiesByClass) {
         this(Stream.of(enabledStrategiesByClass).collect(Collectors.toSet()), Set.of());
     }
-    
-    public AuthorizeProjectJenkinsRule(Set<Class<? extends Describable<?>>> enabledStrategiesByClass, Set<Class<? extends Describable<?>>> disabledStrategiesByClass) {
+
+    public AuthorizeProjectJenkinsRule(
+            Set<Class<? extends Describable<?>>> enabledStrategiesByClass,
+            Set<Class<? extends Describable<?>>> disabledStrategiesByClass) {
         this.enabledStrategiesByClass = enabledStrategiesByClass;
         this.disabledStrategiesByClass = disabledStrategiesByClass;
     }
-    
+
     @Override
     public WebClient createWebClient() {
         return new WebClient() {
             private static final long serialVersionUID = 3389654318647204218L;
-            
+
             @Override
             public void throwFailingHttpStatusCodeExceptionIfNecessary(WebResponse webResponse) {
                 // 405 Method Not Allowed is returned when parameter is required.
@@ -71,7 +69,7 @@ public class AuthorizeProjectJenkinsRule extends JenkinsRule {
             }
         };
     }
-    
+
     public void before() throws Throwable {
         super.before();
         Set<String> enabledStrategies = new HashSet<>();
@@ -82,6 +80,8 @@ public class AuthorizeProjectJenkinsRule extends JenkinsRule {
         for (Class<? extends Describable<?>> clazz : disabledStrategiesByClass) {
             disabledStrategies.add(jenkins.getDescriptor(clazz).getId());
         }
-        QueueItemAuthenticatorConfiguration.get().getAuthenticators().add(new ProjectQueueItemAuthenticator(enabledStrategies, disabledStrategies));
+        QueueItemAuthenticatorConfiguration.get()
+                .getAuthenticators()
+                .add(new ProjectQueueItemAuthenticator(enabledStrategies, disabledStrategies));
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/authorizeproject/testutil/SecurityRealmWithUserFilter.java
+++ b/src/test/java/org/jenkinsci/plugins/authorizeproject/testutil/SecurityRealmWithUserFilter.java
@@ -1,18 +1,18 @@
 /*
  * The MIT License
- * 
+ *
  * Copyright (c) 2016 IKEDA Yasuyuki
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -24,10 +24,8 @@
 
 package org.jenkinsci.plugins.authorizeproject.testutil;
 
-import java.util.List;
-
 import hudson.security.SecurityRealm;
-
+import java.util.List;
 import org.acegisecurity.userdetails.UsernameNotFoundException;
 import org.jvnet.hudson.test.JenkinsRule;
 
@@ -40,26 +38,24 @@ import org.jvnet.hudson.test.JenkinsRule;
 public class SecurityRealmWithUserFilter extends SecurityRealm {
     private final SecurityRealm baseSecurityRealm;
     private final List<String> validUserList;
-    
+
     public SecurityRealmWithUserFilter(SecurityRealm baseSecurityRealm, List<String> validUserList) {
         this.baseSecurityRealm = baseSecurityRealm;
         this.validUserList = validUserList;
     }
-    
+
     @Override
     public SecurityComponents createSecurityComponents() {
         final SecurityComponents baseComponent = baseSecurityRealm.createSecurityComponents();
         return new SecurityComponents(
                 baseComponent.manager,
                 username -> {
-                        if (!validUserList.contains(username)) {
-                            throw new UsernameNotFoundException(
-                                    String.format("%s is not listed as valid username.", username)
-                            );
-                        }
-                        return baseComponent.userDetails.loadUserByUsername(username);
+                    if (!validUserList.contains(username)) {
+                        throw new UsernameNotFoundException(
+                                String.format("%s is not listed as valid username.", username));
+                    }
+                    return baseComponent.userDetails.loadUserByUsername(username);
                 },
-                baseComponent.rememberMe
-        );
+                baseComponent.rememberMe);
     }
 }


### PR DESCRIPTION
## Format Java and pom with parent pom 4.59

- Format pom and Java files with parent pom 4.59
- Exclude formatting commit from git blame

Easier to manage when the formatting is automatic.  Includes the marker file that will allow GitHub to ignore the commit containing the formatting change when reviewing `git blame`.

Fixes line endings on the files in addition to using consistent code formatting.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
