### PR TITLE
Replace Prototype.js with native JavaScript

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/authorizeproject/nestedHelp.js
+++ b/src/main/resources/org/jenkinsci/plugins/authorizeproject/nestedHelp.js
@@ -23,23 +23,23 @@
  */
 Behaviour.register({".authorize-project-nested-help": function(e) {
   // ensure Behavior is applied only once.
-  $(e).removeClassName("authorize-project-nested-help");
-  new Ajax.Request(e.getAttribute("helpURL"), {
-    method : 'get',
-    onSuccess : function(x) {
-      e.innerHTML = x.responseText;
-      var myselfName = e.getAttribute("myselfName");
-      var pluginName = x.getResponseHeader("X-Plugin-Short-Name");
-      if (myselfName != pluginName) {
-        var from = x.getResponseHeader("X-Plugin-From");
-        if (from) {
-          e.innerHTML += "<div class='from-plugin'>"+from+"</div>";
+  e.classList.remove("authorize-project-nested-help");
+  fetch(e.getAttribute("helpURL")).then((rsp) => {
+    if (rsp.ok) {
+      rsp.text().then((responseText) => {
+        e.innerHTML = responseText;
+        var myselfName = e.getAttribute("myselfName");
+        var pluginName = rsp.headers.get("X-Plugin-Short-Name");
+        if (myselfName != pluginName) {
+          var from = rsp.headers.get("X-Plugin-From");
+          if (from) {
+            e.innerHTML += "<div class='from-plugin'>"+from+"</div>";
+          }
         }
-      }
-      layoutUpdateCallback.call();
-    },
-    onFailure : function(x) {
-      e.innerHTML = "<b>ERROR</b>: Failed to load help file: " + x.statusText;
+        layoutUpdateCallback.call();
+      });
+    } else {
+      e.innerHTML = "<b>ERROR</b>: Failed to load help file: " + rsp.statusText;
     }
   });
 }});
@@ -48,6 +48,6 @@ Behaviour.register({".authorize-project-nested-help": function(e) {
  * Allows run Behavior when help is loaded.
  */
 layoutUpdateCallback.add(function() {
-  $$(".authorize-project-nested-help").each(function(e){Behaviour.applySubtree(e, true)});
+  document.querySelectorAll(".authorize-project-nested-help").forEach(function(e){Behaviour.applySubtree(e, true)});
 });
 

--- a/src/main/resources/org/jenkinsci/plugins/authorizeproject/strategy/SpecificUsersAuthorizationStrategy/checkPasswordRequested.js
+++ b/src/main/resources/org/jenkinsci/plugins/authorizeproject/strategy/SpecificUsersAuthorizationStrategy/checkPasswordRequested.js
@@ -66,36 +66,39 @@ Behaviour.specify(".specific-user-authorization", "checkPasswordRequired", 0, fu
     passwordHelpBlock,
   ];
   
-  passwordBlockList.each(function(f) {
+  passwordBlockList.forEach(function(f) {
     if (f != null) {
-      f.hide();
+      f.style.display = 'none';
     }
   });
   
   var onchange = function(evt) {
     var url = useridField.getAttribute("checkPasswordRequestedUrl");
     url = eval(url);
-    var ajax = new Ajax.Request(url, {
-      evalJS: false, // don't evaluate contents automatically.
-      onSuccess: function(response) {
-        var required = eval(response.responseText);
-        if (required) {
-          passwordBlockList.each(function(f) {
-            if (f != null) {
-              f.show();
-            }
-          });
-        } else {
-          passwordBlockList.each(function(f) {
-            if (f != null) {
-              f.hide();
-            }
-          });
-        }
-      },
+    fetch(url, {
+      method: "post",
+      headers: crumb.wrap({}),
+    }).then((rsp) => {
+      if (rsp.ok) {
+        rsp.json().then((required) => {
+          if (required) {
+            passwordBlockList.forEach(f => {
+              if (f != null) {
+                f.style.display = '';
+              }
+            });
+          } else {
+            passwordBlockList.forEach(f => {
+              if (f != null) {
+                f.style.display = 'none';
+              }
+            });
+          }
+        });
+      }
     });
   };
   
-  useridField.observe("change", onchange);
+  useridField.addEventListener("change", onchange);
   onchange.call(useridField);
 });

--- a/src/main/resources/org/jenkinsci/plugins/authorizeproject/strategy/SpecificUsersAuthorizationStrategy/passwordApiTokenSwitch.js
+++ b/src/main/resources/org/jenkinsci/plugins/authorizeproject/strategy/SpecificUsersAuthorizationStrategy/passwordApiTokenSwitch.js
@@ -44,17 +44,17 @@ Behaviour.specify(".specific-user-authorization", "passwordApiTokenSwitch", 0, f
   };
   
   var onchange = function() {
-    var e = this.up(".specific-user-authorization");
+    var e = this.closest(".specific-user-authorization");
     if (this.checked) {
-        e.down('.specific-user-authorization-password').hide();
-        e.down('.specific-user-authorization-apitoken').show();
+        e.querySelector('.specific-user-authorization-password').style.display = 'none';
+        e.querySelector('.specific-user-authorization-apitoken').style.display = '';
     } else {
-        e.down('.specific-user-authorization-password').show();
-        e.down('.specific-user-authorization-apitoken').hide();
+        e.querySelector('.specific-user-authorization-password').style.display = '';
+        e.querySelector('.specific-user-authorization-apitoken').style.display = 'none';
     }
   };
   
   var useApitokenField = findFormItem(e, "useApitoken", findChild(e));
-  useApitokenField.observe("click", onchange);
+  useApitokenField.addEventListener("click", onchange);
   onchange.call(useApitokenField);
 });


### PR DESCRIPTION
See [JENKINS-70906](https://issues.jenkins.io/browse/JENKINS-70906). Jenkins core currently uses [Prototype 1.7](https://github.com/prototypejs/prototype/releases/tag/1.7), released on November 15, 2010. The latest version is [Prototype 1.7.3](https://github.com/prototypejs/prototype/releases/tag/1.7.3), released on September 22, 2015. When an attempt was made to upgrade to 1.7.3 in 2018 in [JENKINS-49319](https://issues.jenkins.io/browse/JENKINS-49319), the change had to be reverted. Therefore this PR removes Prototype usages in favor of native JavaScript. To test this I set breakpoints in all of the changed lines and then clicked around in the UI until I hit all the breakpoints.