### PR TITLE
Use SVG icon for padlock

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/authorizeproject/AuthorizeProjectProperty.java
+++ b/src/main/java/org/jenkinsci/plugins/authorizeproject/AuthorizeProjectProperty.java
@@ -247,7 +247,7 @@ public class AuthorizeProjectProperty extends JobProperty<Job<?, ?>> {
          */
         @Override
         public String getIconFileName() {
-            return ProjectQueueItemAuthenticator.isConfigured() ? "secure.png" : null;
+            return ProjectQueueItemAuthenticator.isConfigured() ? "symbol-lock-closed" : null;
         }
 
         /**
@@ -271,7 +271,7 @@ public class AuthorizeProjectProperty extends JobProperty<Job<?, ?>> {
          */
         @Override
         public String getIconClassName() {
-            return ProjectQueueItemAuthenticator.isConfigured() ? "icon-secure" : null;
+            return ProjectQueueItemAuthenticator.isConfigured() ? "symbol-lock-closed" : null;
         }
 
         /**

--- a/src/main/resources/org/jenkinsci/plugins/authorizeproject/AuthorizeProjectProperty/AuthorizationAction/index.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/authorizeproject/AuthorizeProjectProperty/AuthorizationAction/index.jelly
@@ -30,8 +30,7 @@
     <st:include it="${it.job}" page="sidepanel" optional="true"/>
     <l:main-panel>
       <h1>
-        <!-- TODO l:icon class="${it.iconClassName} icon-xlg" when context menu is icon spec aware-->
-        <l:icon class="icon-secure icon-xlg"/>
+        <l:icon class="${it.iconClassName} icon-xlg"/>
         ${it.displayName}
       </h1>
       <p/>


### PR DESCRIPTION
The PNG icon looked out of place compared to all the other icons which have been converted to SVG. To test this I installed the plugin with these changes and verified I could see the SVG icon on both the Authorization link on the side panel of the build page as well as the page that you get to after clicking on the side panel Authorization link.