### PR TITLE
Test with Jenkins 2.407 and Java 19

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,5 @@
 buildPlugin(useContainerAgent: true, configurations: [
     [platform: 'linux', jdk: 17, jenkins: '2.401.1'],
+    [platform: 'linux', jdk: 19, jenkins: '2.407'],
     [platform: 'windows', jdk: 11],
 ])

--- a/src/test/java/org/jenkinsci/plugins/authorizeproject/GlobalQueueItemAuthenticatorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/authorizeproject/GlobalQueueItemAuthenticatorTest.java
@@ -1,5 +1,6 @@
 package org.jenkinsci.plugins.authorizeproject;
 
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -7,6 +8,7 @@ import hudson.model.FreeStyleProject;
 import hudson.model.User;
 import hudson.security.ACL;
 import hudson.util.DescribableList;
+import hudson.util.VersionNumber;
 import jenkins.model.Jenkins;
 import jenkins.security.QueueItemAuthenticator;
 import jenkins.security.QueueItemAuthenticatorConfiguration;
@@ -15,6 +17,7 @@ import org.jenkinsci.plugins.authorizeproject.strategy.AnonymousAuthorizationStr
 import org.jenkinsci.plugins.authorizeproject.strategy.SpecificUsersAuthorizationStrategy;
 import org.jenkinsci.plugins.authorizeproject.testutil.AuthorizationCheckBuilder;
 import org.jenkinsci.plugins.authorizeproject.testutil.AuthorizeProjectJenkinsRule;
+import org.junit.Assume;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
@@ -85,6 +88,8 @@ public class GlobalQueueItemAuthenticatorTest {
 
     @Test
     public void testConfiguration() throws Exception {
+        // HTMLUnit does not support the fetch JavaScript API, must skip test after 2.401.1
+        Assume.assumeThat(j.jenkins.getVersion().isOlderThan(new VersionNumber("2.402")), is(true));
         GlobalQueueItemAuthenticator auth = new GlobalQueueItemAuthenticator(new AnonymousAuthorizationStrategy());
         QueueItemAuthenticatorConfiguration.get().getAuthenticators().add(auth);
 
@@ -98,6 +103,8 @@ public class GlobalQueueItemAuthenticatorTest {
 
     @Test
     public void testConfigurationWithDescriptorNewInstance() throws Exception {
+        // HTMLUnit does not support the fetch JavaScript API, must skip test after 2.401.1
+        Assume.assumeThat(j.jenkins.getVersion().isOlderThan(new VersionNumber("2.402")), is(true));
         GlobalQueueItemAuthenticator auth =
                 new GlobalQueueItemAuthenticator(new SpecificUsersAuthorizationStrategy("admin"));
         QueueItemAuthenticatorConfiguration.get().getAuthenticators().add(auth);

--- a/src/test/java/org/jenkinsci/plugins/authorizeproject/ProjectQueueItemAuthenticatorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/authorizeproject/ProjectQueueItemAuthenticatorTest.java
@@ -24,6 +24,7 @@
 
 package org.jenkinsci.plugins.authorizeproject;
 
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.*;
 
 import com.gargoylesoftware.htmlunit.html.HtmlForm;
@@ -46,6 +47,7 @@ import hudson.model.User;
 import hudson.security.ACL;
 import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.Builder;
+import hudson.util.VersionNumber;
 import java.io.IOException;
 import java.util.HashSet;
 import java.util.Set;
@@ -61,6 +63,7 @@ import org.jenkinsci.plugins.authorizeproject.testutil.AuthorizeProjectJenkinsRu
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.junit.Assume;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
@@ -195,6 +198,8 @@ public class ProjectQueueItemAuthenticatorTest {
 
     @Test
     public void testDisabledInProjectAuthorization() throws Exception {
+        // HTMLUnit does not support the fetch JavaScript API, must skip test after 2.401.1
+        Assume.assumeThat(j.jenkins.getVersion().isOlderThan(new VersionNumber("2.402")), is(true));
         FreeStyleProject p = j.createFreeStyleProject();
         p.addProperty(new AuthorizeProjectProperty(new AnonymousAuthorizationStrategy()));
 
@@ -367,6 +372,8 @@ public class ProjectQueueItemAuthenticatorTest {
 
     @Test
     public void testGlobalSecurityConfiguration() throws Exception {
+        // HTMLUnit does not support the fetch JavaScript API, must skip test after 2.401.1
+        Assume.assumeThat(j.jenkins.getVersion().isOlderThan(new VersionNumber("2.402")), is(true));
         AuthorizeProjectStrategyWithGlobalSecurityConfiguration.DescriptorImpl descriptor =
                 (AuthorizeProjectStrategyWithGlobalSecurityConfiguration.DescriptorImpl)
                         Jenkins.get().getDescriptor(AuthorizeProjectStrategyWithGlobalSecurityConfiguration.class);


### PR DESCRIPTION
## Test Java 19 and Jenkins 2.407 in CI

HTMLUnit does not support the JavaScript fetch API that is used in the pages of the plugin.  Allow the tests to continue running on older Jenkins versions, accept that they don't run on newer versions.

### Testing done

Ran tests with Jenkins 2.402 through 2.407.

### Submitter checklist

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
