### PR TITLE
Use Jenkinsfile from plugin archetype

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,10 @@
-buildPlugin(useContainerAgent: true, configurations: [
-    [platform: 'linux', jdk: 17, jenkins: '2.401.1'],
-    [platform: 'linux', jdk: 19, jenkins: '2.407'],
+/*
+ See the documentation for more options:
+ https://github.com/jenkins-infra/pipeline-library/
+*/
+buildPlugin(
+  useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
+  configurations: [
+    [platform: 'linux', jdk: 17],
     [platform: 'windows', jdk: 11],
 ])


### PR DESCRIPTION
## Use Jenkinsfile from plugin archetype

Standard is better than better

Java 19 test was interesting but does not add new info

### Testing done

Rely on ci.jenkins.io to confirm new definition.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
