### PR TITLE
Remove Java 19 javadoc warnings

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/authorizeproject/AuthorizeProjectStrategyDescriptor.java
+++ b/src/main/java/org/jenkinsci/plugins/authorizeproject/AuthorizeProjectStrategyDescriptor.java
@@ -38,16 +38,10 @@ import org.kohsuke.stapler.StaplerRequest;
  */
 public abstract class AuthorizeProjectStrategyDescriptor extends Descriptor<AuthorizeProjectStrategy> {
 
-    /**
-     * {@inheritDoc}
-     */
     protected AuthorizeProjectStrategyDescriptor() {
         super();
     }
 
-    /**
-     * {@inheritDoc}
-     */
     protected AuthorizeProjectStrategyDescriptor(Class<? extends AuthorizeProjectStrategy> clazz) {
         super(clazz);
     }


### PR DESCRIPTION
## Fix javadoc warning on Java 19

The @inheritdoc tag cannot be used in constructors

Was ignored before, Java 19 reports a warning

### Testing done

Confirmed javadoc generation no longer has warnings on Java 19 and runs without warnings on Java 11 and Java 20.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
