### PR TITLE
Remove tests that fail due to JavaScript fetch

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/authorizeproject/GlobalQueueItemAuthenticatorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/authorizeproject/GlobalQueueItemAuthenticatorTest.java
@@ -1,6 +1,5 @@
 package org.jenkinsci.plugins.authorizeproject;
 
-import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -8,7 +7,6 @@ import hudson.model.FreeStyleProject;
 import hudson.model.User;
 import hudson.security.ACL;
 import hudson.util.DescribableList;
-import hudson.util.VersionNumber;
 import jenkins.model.Jenkins;
 import jenkins.security.QueueItemAuthenticator;
 import jenkins.security.QueueItemAuthenticatorConfiguration;
@@ -17,11 +15,9 @@ import org.jenkinsci.plugins.authorizeproject.strategy.AnonymousAuthorizationStr
 import org.jenkinsci.plugins.authorizeproject.strategy.SpecificUsersAuthorizationStrategy;
 import org.jenkinsci.plugins.authorizeproject.testutil.AuthorizationCheckBuilder;
 import org.jenkinsci.plugins.authorizeproject.testutil.AuthorizeProjectJenkinsRule;
-import org.junit.Assume;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
-import org.jvnet.hudson.test.JenkinsRule.WebClient;
 
 public class GlobalQueueItemAuthenticatorTest {
     @Rule
@@ -84,49 +80,5 @@ public class GlobalQueueItemAuthenticatorTest {
             j.assertBuildStatusSuccess(p.scheduleBuild2(0));
             assertEquals("bob", checker.authentication.getPrincipal());
         }
-    }
-
-    @Test
-    public void testConfiguration() throws Exception {
-        // HTMLUnit does not support the fetch JavaScript API, must skip test after 2.401.1
-        Assume.assumeThat(j.jenkins.getVersion().isOlderThan(new VersionNumber("2.402")), is(true));
-        GlobalQueueItemAuthenticator auth = new GlobalQueueItemAuthenticator(new AnonymousAuthorizationStrategy());
-        QueueItemAuthenticatorConfiguration.get().getAuthenticators().add(auth);
-
-        WebClient wc = j.createWebClient();
-        j.submit(wc.goTo("configureSecurity").getFormByName("config"));
-
-        j.assertEqualDataBoundBeans(
-                auth,
-                QueueItemAuthenticatorConfiguration.get().getAuthenticators().get(GlobalQueueItemAuthenticator.class));
-    }
-
-    @Test
-    public void testConfigurationWithDescriptorNewInstance() throws Exception {
-        // HTMLUnit does not support the fetch JavaScript API, must skip test after 2.401.1
-        Assume.assumeThat(j.jenkins.getVersion().isOlderThan(new VersionNumber("2.402")), is(true));
-        GlobalQueueItemAuthenticator auth =
-                new GlobalQueueItemAuthenticator(new SpecificUsersAuthorizationStrategy("admin"));
-        QueueItemAuthenticatorConfiguration.get().getAuthenticators().add(auth);
-
-        WebClient wc = j.createWebClient();
-        j.submit(wc.goTo("configureSecurity").getFormByName("config"));
-
-        /*
-        // as SpecificUsersAuthorizationStrategy is not annotated with @DataBoundConstructor,
-        // assertEqualDataBoundBeans is not applicable.
-        j.assertEqualDataBoundBeans(
-                auth,
-                QueueItemAuthenticatorConfiguration.get().getAuthenticators().get(GlobalQueueItemAuthenticator.class)
-        );
-        */
-        AuthorizeProjectStrategy strategy = QueueItemAuthenticatorConfiguration.get()
-                .getAuthenticators()
-                .get(GlobalQueueItemAuthenticator.class)
-                .getStrategy();
-        assertEquals(SpecificUsersAuthorizationStrategy.class, strategy.getClass());
-        assertEquals("admin", ((SpecificUsersAuthorizationStrategy) strategy).getUserid());
-        // Don't care about noNeedReauthentication
-        // (It might be removed for GlobalQueueItemAuthenticator in future)
     }
 }


### PR DESCRIPTION
## Remove tests that fail due to JavaScript fetch

The tests are not valuable enough to justify heroics trying to retain them when the JavaScript code is using the `fetch` API that is not supported by HTMLUnit.

https://github.com/jenkinsci/bom/pull/2338 showed the need for this with the most recent release of the role-strategy plugin.  The recent release needs the authorize project plugin when running tests in the plugin compatibility tester.

### Testing done

Confirmed that tests have been removed as expected.  Previously reported 4 skipped tests when testing with Jenkins 2.417.  Now reports no skipped tests when testing with Jenkins 2.417.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
