### PR TITLE
Replace deprecated functions with standard JS

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/authorizeproject/strategy/SpecificUsersAuthorizationStrategy/checkPasswordRequested.js
+++ b/src/main/resources/org/jenkinsci/plugins/authorizeproject/strategy/SpecificUsersAuthorizationStrategy/checkPasswordRequested.js
@@ -45,16 +45,16 @@ Behaviour.specify(".specific-user-authorization", "checkPasswordRequired", 0, fu
   
   var useridField = findFormItem(e, "userid", findChild(e));
   var passwordField = findFormItem(e, "password", findChild(e));
-  var passwordFieldBlock = findAncestor(passwordField, "TR");
+  var passwordFieldBlock = passwordField.closest("TR");
   /*
     [JENKINS-64341] - In Jenkins version greater than 2.263.4
     the table tags for fields (in forms) were replaced by div tags.
-    Since the changes were applied the 'findAncestor(passwordField, "TR")'
+    Since the changes were applied the 'passwordField.closest("TR")'
     method returns null. It is necessary to use the method
-    'findAncestorClass(passwordField, "tr")' instead of.
+    'passwordField.closest(".tr")' instead.
   */
   if (passwordFieldBlock == null) {
-      passwordFieldBlock = findAncestorClass(passwordField, "tr");
+      passwordFieldBlock = passwordField.closest(".tr");
     }
 
   var passwordCheckBlock = findFollowingTR(passwordField, "validation-error-area");


### PR DESCRIPTION
This inlines a deprecated function https://github.com/jenkinsci/jenkins/blob/551043065bc672102fb8b07e8008f959ebc566fa/war/src/main/webapp/scripts/hudson-behavior.js#L453

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
