### PR TITLE
Omit spotbugs CT_CONSTRUCTOR_THROWS visitor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,10 +50,13 @@
     <changelist>-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/authorize-project-plugin</gitHubRepo>
     <jenkins.version>2.401.3</jenkins.version>
-    <spotbugs.effort>Max</spotbugs.effort>
     <!-- TODO: Remove when plugin pom is using this version or newer -->
     <!-- https://github.com/jenkinsci/plugin-pom/pull/869 -->
     <spotbugs-maven-plugin.version>4.8.2.0</spotbugs-maven-plugin.version>
+    <spotbugs.effort>Max</spotbugs.effort>
+    <!-- TODO: Remove when plugin pom includes this omitVisitors -->
+    <!-- https://github.com/jenkinsci/plugin-pom/pull/869 -->
+    <spotbugs.omitVisitors>ConstructorThrow,FindReturnRef</spotbugs.omitVisitors>
     <spotbugs.threshold>Low</spotbugs.threshold>
     <spotless.check.skip>false</spotless.check.skip>
   </properties>

--- a/src/spotbugs/excludesFilter.xml
+++ b/src/spotbugs/excludesFilter.xml
@@ -23,10 +23,6 @@
       exclusion from this section.
    -->
   <Match>
-    <Bug pattern="CT_CONSTRUCTOR_THROW"/>
-    <Class name="org.jenkinsci.plugins.authorizeproject.strategy.SpecificUsersAuthorizationStrategy"/>
-  </Match>
-  <Match>
     <Bug pattern="SIC_INNER_SHOULD_BE_STATIC_ANON"/>
     <Class name="org.jenkinsci.plugins.authorizeproject.GlobalQueueItemAuthenticator$DescriptorImpl"/>
   </Match>


### PR DESCRIPTION
From https://github.com/jenkinsci/plugin-pom/pull/869#issuecomment-1860918407

> Discussion in spotbugs/spotbugs#2695
> https://wiki.sei.cmu.edu/confluence/display/java/OBJ11-J.+Be+wary+of+letting+constructors+throw+exceptions
> seems to relate to libraries used with SecurityManager which is dead
> and certainly does not apply to Jenkins; we do not expect untrusted code
> to be running inside the controller JVM, and it does not seem plausible
> that finalizer abuse would happen by accident.
