### PR TITLE
Remove redundant spotbugs details from pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,13 +50,7 @@
     <changelist>-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/authorize-project-plugin</gitHubRepo>
     <jenkins.version>2.401.3</jenkins.version>
-    <!-- TODO: Remove when plugin pom is using this version or newer -->
-    <!-- https://github.com/jenkinsci/plugin-pom/pull/869 -->
-    <spotbugs-maven-plugin.version>4.8.2.0</spotbugs-maven-plugin.version>
     <spotbugs.effort>Max</spotbugs.effort>
-    <!-- TODO: Remove when plugin pom includes this omitVisitors -->
-    <!-- https://github.com/jenkinsci/plugin-pom/pull/869 -->
-    <spotbugs.omitVisitors>ConstructorThrow,FindReturnRef</spotbugs.omitVisitors>
     <spotbugs.threshold>Low</spotbugs.threshold>
     <spotless.check.skip>false</spotless.check.skip>
   </properties>


### PR DESCRIPTION
## Remove redundant spotbugs details from pom

[Plugin pom 4.77](https://github.com/jenkinsci/plugin-pom/releases/tag/plugin-4.77) includes those details.  No need to include them in the pom of this plugin.

### Testing done

Confirmed that automated tests pass locally and no new spotbugs warnigs are introduced.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Automated tests pass locally
- [x] Link to relevant pull requests, esp. upstream and downstream changes
