### PR TITLE
Fix WebClient missing polyfill

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/authorizeproject/testutil/AuthorizeProjectJenkinsRule.java
+++ b/src/test/java/org/jenkinsci/plugins/authorizeproject/testutil/AuthorizeProjectJenkinsRule.java
@@ -56,7 +56,7 @@ public class AuthorizeProjectJenkinsRule extends JenkinsRule {
 
     @Override
     public WebClient createWebClient() {
-        return new WebClient() {
+        WebClient webClient = new WebClient() {
             private static final long serialVersionUID = 3389654318647204218L;
 
             @Override
@@ -68,6 +68,8 @@ public class AuthorizeProjectJenkinsRule extends JenkinsRule {
                 super.throwFailingHttpStatusCodeExceptionIfNecessary(webResponse);
             }
         };
+        webClient.getOptions().setFetchPolyfillEnabled(true);
+        return webClient;
     }
 
     public void before() throws Throwable {


### PR DESCRIPTION
Thanks to @basil for raising awareness of this - https://github.com/jenkinsci/jenkins/pull/9148#issuecomment-2168720511. 

We're now using the JavaScript `fetch()` API for the builds widget which requires a polyfill for HtmlUnit. This polyfill is enabled by default as part of the Jenkins test harness `createWebClient()`, however in this case that method wasn't used as a couple of methods of WebClient needed to be overridden. 

This MR enables the polyfill for that web client.

### Testing done

* Test passes on latest snapshot

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
