### PR TITLE
Require Jenkins 2.440.3 or newer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     <revision>1.7.3</revision>
     <changelist>-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/authorize-project-plugin</gitHubRepo>
-    <jenkins.baseline>2.426</jenkins.baseline>
+    <jenkins.baseline>2.440</jenkins.baseline>
     <jenkins.version>${jenkins.baseline}.3</jenkins.version>
     <spotbugs.effort>Max</spotbugs.effort>
     <spotbugs.threshold>Low</spotbugs.threshold>


### PR DESCRIPTION
## Require Jenkins 2.440.3 or newer

The plugin bill of materials for 2.426.x has received its last update.  Switch to Jenkins 2.440.3 as the minimum Jenkins version.

Security fixes in Jenkins 2.440.3 are good for users and most users that are actively upgrading Jenkins core and plugins are already running a newer version.

### Testing done

None.  Rely on ci.jenkins.io

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
