### PR TITLE
Require Jenkins 2.479.1 or newer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.88</version>
+    <version>5.5</version>
     <relativePath />
   </parent>
 
@@ -33,8 +33,9 @@
     <revision>1.8.2</revision>
     <changelist>-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/authorize-project-plugin</gitHubRepo>
-    <jenkins.baseline>2.452</jenkins.baseline>
-    <jenkins.version>${jenkins.baseline}.4</jenkins.version>
+    <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
+    <jenkins.baseline>2.479</jenkins.baseline>
+    <jenkins.version>${jenkins.baseline}.1</jenkins.version>
     <spotbugs.effort>Max</spotbugs.effort>
     <spotbugs.threshold>Low</spotbugs.threshold>
     <spotless.check.skip>false</spotless.check.skip>
@@ -45,7 +46,7 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-${jenkins.baseline}.x</artifactId>
-        <version>3944.v1a_e4f8b_452db_</version>
+        <version>4023.va_eeb_b_4e45f07</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/src/main/java/org/jenkinsci/plugins/authorizeproject/AuthorizeProjectProperty.java
+++ b/src/main/java/org/jenkinsci/plugins/authorizeproject/AuthorizeProjectProperty.java
@@ -40,12 +40,12 @@ import hudson.model.JobProperty;
 import hudson.model.JobPropertyDescriptor;
 import hudson.model.Queue;
 import hudson.util.FormApply;
+import jakarta.servlet.ServletException;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import javax.servlet.ServletException;
 import jenkins.model.Jenkins;
 import jenkins.model.TransientActionFactory;
 import net.sf.json.JSONObject;
@@ -55,7 +55,7 @@ import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.HttpResponse;
-import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerRequest2;
 import org.kohsuke.stapler.interceptor.RequirePOST;
 
 /**
@@ -139,7 +139,7 @@ public class AuthorizeProjectProperty extends JobProperty<Job<?, ?>> {
      * {@inheritDoc}
      */
     @Override
-    public JobProperty<?> reconfigure(StaplerRequest req, JSONObject form) throws Descriptor.FormException {
+    public JobProperty<?> reconfigure(StaplerRequest2 req, JSONObject form) throws Descriptor.FormException {
         // This is called when the job configuration is submitted.
         // authorize-project is preserved in job configuration pages.
         // It is updated via AuthorizationAction instead.
@@ -284,7 +284,8 @@ public class AuthorizeProjectProperty extends JobProperty<Job<?, ?>> {
         @RequirePOST
         @NonNull
         @Restricted(NoExternalUse.class)
-        public synchronized HttpResponse doAuthorize(@NonNull StaplerRequest req) throws IOException, ServletException {
+        public synchronized HttpResponse doAuthorize(@NonNull StaplerRequest2 req)
+                throws IOException, ServletException {
             job.checkPermission(Job.CONFIGURE);
             JSONObject json = req.getSubmittedForm();
             JSONObject o = json.optJSONObject(getPropertyDescriptor().getJsonSafeClassName());

--- a/src/main/java/org/jenkinsci/plugins/authorizeproject/AuthorizeProjectStrategy.java
+++ b/src/main/java/org/jenkinsci/plugins/authorizeproject/AuthorizeProjectStrategy.java
@@ -42,7 +42,7 @@ import jenkins.model.Jenkins;
 import org.acegisecurity.AccessDeniedException;
 import org.acegisecurity.Authentication;
 import org.kohsuke.stapler.Stapler;
-import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerRequest2;
 
 /**
  * Extension point to define a new strategy to authorize builds configured in project configuration pages.
@@ -182,7 +182,7 @@ public abstract class AuthorizeProjectStrategy extends AbstractDescribableImpl<A
             // It may not be allowed even if the user is an administrator of the job.
             return;
         }
-        StaplerRequest request = Stapler.getCurrentRequest();
+        StaplerRequest2 request = Stapler.getCurrentRequest2();
         AccessControlled context = (request != null) ? request.findAncestorObject(AccessControlled.class) : null;
         if (context == null) {
             context = Jenkins.get();

--- a/src/main/java/org/jenkinsci/plugins/authorizeproject/AuthorizeProjectStrategyDescriptor.java
+++ b/src/main/java/org/jenkinsci/plugins/authorizeproject/AuthorizeProjectStrategyDescriptor.java
@@ -31,7 +31,7 @@ import java.util.ArrayList;
 import java.util.List;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
-import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerRequest2;
 
 /**
  * Base {@link Descriptor} class for {@link AuthorizeProjectStrategy} instances.
@@ -91,7 +91,7 @@ public abstract class AuthorizeProjectStrategyDescriptor extends Descriptor<Auth
      * Invoked when configuration is submitted from "Configure Global Security" as a child of {@link ProjectQueueItemAuthenticator}.
      * You should call save() by yourself.
      */
-    public void configureFromGlobalSecurity(StaplerRequest req, JSONObject js) throws FormException {}
+    public void configureFromGlobalSecurity(StaplerRequest2 req, JSONObject js) throws FormException {}
 
     /**
      * @return this strategy can be enabled by default.

--- a/src/main/java/org/jenkinsci/plugins/authorizeproject/AuthorizeProjectUtil.java
+++ b/src/main/java/org/jenkinsci/plugins/authorizeproject/AuthorizeProjectUtil.java
@@ -30,7 +30,7 @@ import hudson.model.Descriptor;
 import hudson.model.Descriptor.FormException;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
-import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerRequest2;
 
 /**
  *
@@ -40,7 +40,7 @@ public class AuthorizeProjectUtil {
      * Create a new {@link Describable} object from user inputs.
      */
     public static <T extends Describable<?>> T bindJSONWithDescriptor(
-            StaplerRequest req, JSONObject formData, String fieldName, Class<T> clazz) throws FormException {
+            StaplerRequest2 req, JSONObject formData, String fieldName, Class<T> clazz) throws FormException {
         formData = formData.getJSONObject(fieldName);
         if (formData == null || formData.isNullObject()) {
             return null;

--- a/src/main/java/org/jenkinsci/plugins/authorizeproject/ConfigurationPermissionEnforcer.java
+++ b/src/main/java/org/jenkinsci/plugins/authorizeproject/ConfigurationPermissionEnforcer.java
@@ -12,7 +12,7 @@ import net.sf.json.JSONObject;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerRequest2;
 
 /**
  * A dummy {@link JobProperty} responsible for providing the {@link AuthorizeProjectStrategy} with a veto over job
@@ -47,7 +47,7 @@ public class ConfigurationPermissionEnforcer extends JobProperty<Job<?, ?>> {
          * {@inheritDoc}
          */
         @Override
-        public JobProperty<?> newInstance(@NonNull StaplerRequest req, JSONObject formData) throws FormException {
+        public JobProperty<?> newInstance(@NonNull StaplerRequest2 req, JSONObject formData) throws FormException {
             Job<?, ?> job = req.findAncestorObject(Job.class);
             AccessControlled context = req.findAncestorObject(AccessControlled.class);
             checkConfigurePermission(job, context);

--- a/src/main/java/org/jenkinsci/plugins/authorizeproject/GlobalQueueItemAuthenticator.java
+++ b/src/main/java/org/jenkinsci/plugins/authorizeproject/GlobalQueueItemAuthenticator.java
@@ -11,7 +11,7 @@ import net.sf.json.JSONObject;
 import org.acegisecurity.Authentication;
 import org.jenkinsci.plugins.authorizeproject.strategy.AnonymousAuthorizationStrategy;
 import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerRequest2;
 
 /**
  * A global default authenticator to allow changing the default for all projects.
@@ -65,13 +65,13 @@ public class GlobalQueueItemAuthenticator extends QueueItemAuthenticator {
 
         /**
          * Creates new {@link GlobalQueueItemAuthenticator} from inputs.
-         * This is required to call {@link hudson.model.Descriptor#newInstance(StaplerRequest, JSONObject)}
+         * This is required to call {@link hudson.model.Descriptor#newInstance(StaplerRequest2, JSONObject)}
          * of {@link AuthorizeProjectProperty}.
          *
-         * @see hudson.model.Descriptor#newInstance(org.kohsuke.stapler.StaplerRequest, net.sf.json.JSONObject)
+         * @see hudson.model.Descriptor#newInstance(org.kohsuke.stapler.StaplerRequest2, net.sf.json.JSONObject)
          */
         @Override
-        public GlobalQueueItemAuthenticator newInstance(StaplerRequest req, JSONObject formData) throws FormException {
+        public GlobalQueueItemAuthenticator newInstance(StaplerRequest2 req, JSONObject formData) throws FormException {
             if (formData == null || formData.isNullObject()) {
                 return null;
             }

--- a/src/main/java/org/jenkinsci/plugins/authorizeproject/ProjectQueueItemAuthenticator.java
+++ b/src/main/java/org/jenkinsci/plugins/authorizeproject/ProjectQueueItemAuthenticator.java
@@ -43,7 +43,7 @@ import jenkins.security.QueueItemAuthenticatorDescriptor;
 import net.sf.json.JSONObject;
 import org.acegisecurity.Authentication;
 import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerRequest2;
 
 /**
  * Authorize builds of projects configured with {@link AuthorizeProjectProperty}.
@@ -179,10 +179,11 @@ public class ProjectQueueItemAuthenticator extends QueueItemAuthenticator {
          * @param formData the form data.
          * @return the authenticator.
          * @throws hudson.model.Descriptor.FormException if the submitted form is invalid.
-         * @see hudson.model.Descriptor#newInstance(org.kohsuke.stapler.StaplerRequest, net.sf.json.JSONObject)
+         * @see hudson.model.Descriptor#newInstance(org.kohsuke.stapler.StaplerRequest2, net.sf.json.JSONObject)
          */
         @Override
-        public ProjectQueueItemAuthenticator newInstance(StaplerRequest req, JSONObject formData) throws FormException {
+        public ProjectQueueItemAuthenticator newInstance(StaplerRequest2 req, JSONObject formData)
+                throws FormException {
             Set<String> enabledStrategies = new HashSet<>();
             Set<String> disabledStrategies = new HashSet<>();
 

--- a/src/main/java/org/jenkinsci/plugins/authorizeproject/strategy/SpecificUsersAuthorizationStrategy.java
+++ b/src/main/java/org/jenkinsci/plugins/authorizeproject/strategy/SpecificUsersAuthorizationStrategy.java
@@ -54,7 +54,7 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
-import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerRequest2;
 
 /**
  * Run builds as a user specified in project configuration pages.
@@ -290,7 +290,7 @@ public class SpecificUsersAuthorizationStrategy extends AuthorizeProjectStrategy
          */
         @Restricted(NoExternalUse.class) // used by stapler/jelly
         @SuppressWarnings("unused")
-        public String doCheckPasswordRequested(StaplerRequest req, @QueryParameter String userid) {
+        public String doCheckPasswordRequested(StaplerRequest2 req, @QueryParameter String userid) {
             return Boolean.toString(isAuthenticationRequired(userid.trim()));
         }
 
@@ -324,7 +324,7 @@ public class SpecificUsersAuthorizationStrategy extends AuthorizeProjectStrategy
         @Restricted(NoExternalUse.class) // used by stapler/jelly
         @SuppressWarnings("unused")
         public FormValidation doCheckPassword(
-                StaplerRequest req,
+                StaplerRequest2 req,
                 @QueryParameter String userid,
                 @QueryParameter String password,
                 @QueryParameter String apitoken,

--- a/src/main/java/org/jenkinsci/plugins/authorizeproject/strategy/SystemAuthorizationStrategy.java
+++ b/src/main/java/org/jenkinsci/plugins/authorizeproject/strategy/SystemAuthorizationStrategy.java
@@ -40,7 +40,7 @@ import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
-import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerRequest2;
 
 /**
  * Run builds as {@link ACL#SYSTEM}. Using this strategy becomes important when
@@ -176,7 +176,7 @@ public class SystemAuthorizationStrategy extends AuthorizeProjectStrategy {
          * {@inheritDoc}
          */
         @Override
-        public void configureFromGlobalSecurity(StaplerRequest req, JSONObject js) throws FormException {
+        public void configureFromGlobalSecurity(StaplerRequest2 req, JSONObject js) throws FormException {
             setPermitReconfiguration(js.getBoolean("permitReconfiguration"));
         }
 
@@ -184,7 +184,7 @@ public class SystemAuthorizationStrategy extends AuthorizeProjectStrategy {
          * {@inheritDoc}
          */
         @Override
-        public SystemAuthorizationStrategy newInstance(StaplerRequest req, JSONObject formData) throws FormException {
+        public SystemAuthorizationStrategy newInstance(StaplerRequest2 req, JSONObject formData) throws FormException {
             SystemAuthorizationStrategy result = (SystemAuthorizationStrategy) super.newInstance(req, formData);
             Jenkins instance = Jenkins.get();
             if (!instance.hasPermission(Jenkins.RUN_SCRIPTS)) {

--- a/src/test/java/org/jenkinsci/plugins/authorizeproject/ProjectQueueItemAuthenticatorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/authorizeproject/ProjectQueueItemAuthenticatorTest.java
@@ -70,7 +70,7 @@ import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.JenkinsRule.WebClient;
 import org.jvnet.hudson.test.TestExtension;
 import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerRequest2;
 
 public class ProjectQueueItemAuthenticatorTest {
     @Rule
@@ -284,7 +284,8 @@ public class ProjectQueueItemAuthenticatorTest {
             }
 
             @Override
-            public void configureFromGlobalSecurity(StaplerRequest req, JSONObject js) throws Descriptor.FormException {
+            public void configureFromGlobalSecurity(StaplerRequest2 req, JSONObject js)
+                    throws Descriptor.FormException {
                 throw new FormException("Should not be called for global-security.jelly is not defined.", "");
             }
         }
@@ -320,7 +321,8 @@ public class ProjectQueueItemAuthenticatorTest {
             }
 
             @Override
-            public void configureFromGlobalSecurity(StaplerRequest req, JSONObject js) throws Descriptor.FormException {
+            public void configureFromGlobalSecurity(StaplerRequest2 req, JSONObject js)
+                    throws Descriptor.FormException {
                 value = js.getString("value");
                 save();
             }
@@ -358,7 +360,8 @@ public class ProjectQueueItemAuthenticatorTest {
             }
 
             @Override
-            public void configureFromGlobalSecurity(StaplerRequest req, JSONObject js) throws Descriptor.FormException {
+            public void configureFromGlobalSecurity(StaplerRequest2 req, JSONObject js)
+                    throws Descriptor.FormException {
                 value = js.getString("value");
                 save();
             }

--- a/src/test/java/org/jenkinsci/plugins/authorizeproject/strategy/SpecificUsersAuthorizationStrategyTest.java
+++ b/src/test/java/org/jenkinsci/plugins/authorizeproject/strategy/SpecificUsersAuthorizationStrategyTest.java
@@ -345,7 +345,7 @@ public class SpecificUsersAuthorizationStrategyTest {
         wc.login("test1");
 
         // GET config.xml of srcProject (userid is set to test1)
-        String configXml = getConfigXml(wc.goToXml(String.format("%s/config.xml", srcProject.getUrl())));
+        String configXml = getConfigXml(wc.goToXml("%s/config.xml".formatted(srcProject.getUrl())));
 
         // POST config.xml of srcProject (userid is set to test1) to a new project.
         // This should success.
@@ -354,7 +354,7 @@ public class SpecificUsersAuthorizationStrategyTest {
         String projectName = destProject.getFullName();
 
         WebRequest req = new WebRequest(
-                new URL(wc.getContextPath() + String.format("%s/config.xml", destProject.getUrl())), HttpMethod.POST);
+                new URL("%s%s/config.xml".formatted(wc.getContextPath(), destProject.getUrl())), HttpMethod.POST);
         req.setAdditionalHeader(
                 j.jenkins.getCrumbIssuer().getCrumbRequestField(),
                 j.jenkins.getCrumbIssuer().getCrumb((jakarta.servlet.ServletRequest) null));
@@ -398,7 +398,7 @@ public class SpecificUsersAuthorizationStrategyTest {
         wc.login("test1");
 
         // GET config.xml of srcProject (userid is set to admin)
-        String configXml = getConfigXml(wc.goToXml(String.format("%s/config.xml", srcProject.getUrl())));
+        String configXml = getConfigXml(wc.goToXml("%s/config.xml".formatted(srcProject.getUrl())));
 
         // POST config.xml of srcProject (userid is set to admin) to a new project.
         // This should fail.
@@ -407,7 +407,7 @@ public class SpecificUsersAuthorizationStrategyTest {
         String projectName = destProject.getFullName();
 
         WebRequest req = new WebRequest(
-                new URL(wc.getContextPath() + String.format("%s/config.xml", destProject.getUrl())), HttpMethod.POST);
+                new URL("%s%s/config.xml".formatted(wc.getContextPath(), destProject.getUrl())), HttpMethod.POST);
         req.setAdditionalHeader(
                 j.jenkins.getCrumbIssuer().getCrumbRequestField(),
                 j.jenkins.getCrumbIssuer().getCrumb((jakarta.servlet.ServletRequest) null));

--- a/src/test/java/org/jenkinsci/plugins/authorizeproject/strategy/SpecificUsersAuthorizationStrategyTest.java
+++ b/src/test/java/org/jenkinsci/plugins/authorizeproject/strategy/SpecificUsersAuthorizationStrategyTest.java
@@ -357,7 +357,7 @@ public class SpecificUsersAuthorizationStrategyTest {
                 new URL(wc.getContextPath() + String.format("%s/config.xml", destProject.getUrl())), HttpMethod.POST);
         req.setAdditionalHeader(
                 j.jenkins.getCrumbIssuer().getCrumbRequestField(),
-                j.jenkins.getCrumbIssuer().getCrumb(null));
+                j.jenkins.getCrumbIssuer().getCrumb((jakarta.servlet.ServletRequest) null));
         req.setRequestBody(configXml);
         wc.getPage(req);
 
@@ -410,7 +410,7 @@ public class SpecificUsersAuthorizationStrategyTest {
                 new URL(wc.getContextPath() + String.format("%s/config.xml", destProject.getUrl())), HttpMethod.POST);
         req.setAdditionalHeader(
                 j.jenkins.getCrumbIssuer().getCrumbRequestField(),
-                j.jenkins.getCrumbIssuer().getCrumb(null));
+                j.jenkins.getCrumbIssuer().getCrumb((jakarta.servlet.ServletRequest) null));
         req.setRequestBody(configXml);
 
         assertThrows(FailingHttpStatusCodeException.class, () -> wc.getPage(req));

--- a/src/test/java/org/jenkinsci/plugins/authorizeproject/strategy/SystemAuthorizationStrategyTest.java
+++ b/src/test/java/org/jenkinsci/plugins/authorizeproject/strategy/SystemAuthorizationStrategyTest.java
@@ -173,7 +173,7 @@ public class SystemAuthorizationStrategyTest {
         wc.login("admin");
 
         // GET config.xml of srcProject
-        String configXml = getConfigXml(wc.goToXml(String.format("%s/config.xml", srcProject.getUrl())));
+        String configXml = getConfigXml(wc.goToXml("%s/config.xml".formatted(srcProject.getUrl())));
 
         // POST config.xml of srcProject to a new project.
         // This should success.
@@ -182,7 +182,7 @@ public class SystemAuthorizationStrategyTest {
         String projectName = destProject.getFullName();
 
         WebRequest req = new WebRequest(
-                new URL(wc.getContextPath() + String.format("%s/config.xml", destProject.getUrl())), HttpMethod.POST);
+                new URL(wc.getContextPath() + "%s/config.xml".formatted(destProject.getUrl())), HttpMethod.POST);
         req.setAdditionalHeader(
                 j.jenkins.getCrumbIssuer().getCrumbRequestField(),
                 j.jenkins.getCrumbIssuer().getCrumb((jakarta.servlet.ServletRequest) null));
@@ -223,7 +223,7 @@ public class SystemAuthorizationStrategyTest {
                 .setPermitReconfiguration(true);
 
         // GET config.xml of srcProject
-        String configXml = getConfigXml(wc.goToXml(String.format("%s/config.xml", srcProject.getUrl())));
+        String configXml = getConfigXml(wc.goToXml("%s/config.xml".formatted(srcProject.getUrl())));
 
         // POST config.xml of srcProject (userid is set to admin) to a new project.
         // This should fail.
@@ -232,7 +232,7 @@ public class SystemAuthorizationStrategyTest {
         String projectName = destProject.getFullName();
 
         WebRequest req = new WebRequest(
-                new URL(wc.getContextPath() + String.format("%s/config.xml", destProject.getUrl())), HttpMethod.POST);
+                new URL(wc.getContextPath() + "%s/config.xml".formatted(destProject.getUrl())), HttpMethod.POST);
         req.setAdditionalHeader(
                 j.jenkins.getCrumbIssuer().getCrumbRequestField(),
                 j.jenkins.getCrumbIssuer().getCrumb((jakarta.servlet.ServletRequest) null));

--- a/src/test/java/org/jenkinsci/plugins/authorizeproject/strategy/SystemAuthorizationStrategyTest.java
+++ b/src/test/java/org/jenkinsci/plugins/authorizeproject/strategy/SystemAuthorizationStrategyTest.java
@@ -185,7 +185,7 @@ public class SystemAuthorizationStrategyTest {
                 new URL(wc.getContextPath() + String.format("%s/config.xml", destProject.getUrl())), HttpMethod.POST);
         req.setAdditionalHeader(
                 j.jenkins.getCrumbIssuer().getCrumbRequestField(),
-                j.jenkins.getCrumbIssuer().getCrumb(null));
+                j.jenkins.getCrumbIssuer().getCrumb((jakarta.servlet.ServletRequest) null));
         req.setRequestBody(configXml);
         wc.getPage(req);
 
@@ -235,7 +235,7 @@ public class SystemAuthorizationStrategyTest {
                 new URL(wc.getContextPath() + String.format("%s/config.xml", destProject.getUrl())), HttpMethod.POST);
         req.setAdditionalHeader(
                 j.jenkins.getCrumbIssuer().getCrumbRequestField(),
-                j.jenkins.getCrumbIssuer().getCrumb(null));
+                j.jenkins.getCrumbIssuer().getCrumb((jakarta.servlet.ServletRequest) null));
         req.setRequestBody(configXml);
 
         assertThrows(FailingHttpStatusCodeException.class, () -> wc.getPage(req));

--- a/src/test/java/org/jenkinsci/plugins/authorizeproject/testutil/SecurityRealmWithUserFilter.java
+++ b/src/test/java/org/jenkinsci/plugins/authorizeproject/testutil/SecurityRealmWithUserFilter.java
@@ -51,8 +51,7 @@ public class SecurityRealmWithUserFilter extends SecurityRealm {
                 baseComponent.manager,
                 username -> {
                     if (!validUserList.contains(username)) {
-                        throw new UsernameNotFoundException(
-                                String.format("%s is not listed as valid username.", username));
+                        throw new UsernameNotFoundException("%s is not listed as valid username.".formatted(username));
                     }
                     return baseComponent.userDetails.loadUserByUsername(username);
                 },


### PR DESCRIPTION
## Require Jenkins 2.479.1 or newer

Use Jakarta EE 9 and Spring Security 6.x instead of Java EE 8 and Spring Security 5.x.

### Testing done

Confirmed that automated tests pass.

The [job and node ownership plugin](https://plugins.jenkins.io/ownership/) has an optional dependency on this plugin.  That plugin also has 3 open security vulnerabilities, a [tables to divs known issue](https://github.com/jenkinsci/ownership-plugin/pull/86), a [55% health score](https://plugins.jenkins.io/ownership/healthscore/), was last released 4 years ago, and has less than 1700 installations. [Plugin installation data](https://old.stats.jenkins.io/pluginversions/ownership.html) indicates that less than 25% of the installations are running a Jenkins version released in the last 6 months.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
