### PR TITLE
Migrate from EE 8 to EE 9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.88</version>
+    <version>5.5</version>
     <relativePath />
   </parent>
 
@@ -33,8 +33,9 @@
     <revision>1.8.2</revision>
     <changelist>-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/authorize-project-plugin</gitHubRepo>
-    <jenkins.baseline>2.452</jenkins.baseline>
-    <jenkins.version>${jenkins.baseline}.4</jenkins.version>
+    <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
+    <jenkins.baseline>2.479</jenkins.baseline>
+    <jenkins.version>${jenkins.baseline}.1</jenkins.version>
     <spotbugs.effort>Max</spotbugs.effort>
     <spotbugs.threshold>Low</spotbugs.threshold>
     <spotless.check.skip>false</spotless.check.skip>

--- a/src/main/java/org/jenkinsci/plugins/authorizeproject/AuthorizeProjectProperty.java
+++ b/src/main/java/org/jenkinsci/plugins/authorizeproject/AuthorizeProjectProperty.java
@@ -40,23 +40,23 @@ import hudson.model.JobProperty;
 import hudson.model.JobPropertyDescriptor;
 import hudson.model.Queue;
 import hudson.util.FormApply;
+import jakarta.servlet.ServletException;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import javax.servlet.ServletException;
 import jenkins.model.Jenkins;
 import jenkins.model.TransientActionFactory;
 import net.sf.json.JSONObject;
-import org.acegisecurity.Authentication;
 import org.jenkins.ui.icon.IconSpec;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.HttpResponse;
-import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerRequest2;
 import org.kohsuke.stapler.interceptor.RequirePOST;
+import org.springframework.security.core.Authentication;
 
 /**
  * Specifies how to authorize its builds.
@@ -139,7 +139,7 @@ public class AuthorizeProjectProperty extends JobProperty<Job<?, ?>> {
      * {@inheritDoc}
      */
     @Override
-    public JobProperty<?> reconfigure(StaplerRequest req, JSONObject form) throws Descriptor.FormException {
+    public JobProperty<?> reconfigure(StaplerRequest2 req, JSONObject form) throws Descriptor.FormException {
         // This is called when the job configuration is submitted.
         // authorize-project is preserved in job configuration pages.
         // It is updated via AuthorizationAction instead.
@@ -284,7 +284,8 @@ public class AuthorizeProjectProperty extends JobProperty<Job<?, ?>> {
         @RequirePOST
         @NonNull
         @Restricted(NoExternalUse.class)
-        public synchronized HttpResponse doAuthorize(@NonNull StaplerRequest req) throws IOException, ServletException {
+        public synchronized HttpResponse doAuthorize(@NonNull StaplerRequest2 req)
+                throws IOException, ServletException {
             job.checkPermission(Job.CONFIGURE);
             JSONObject json = req.getSubmittedForm();
             JSONObject o = json.optJSONObject(getPropertyDescriptor().getJsonSafeClassName());

--- a/src/main/java/org/jenkinsci/plugins/authorizeproject/AuthorizeProjectStrategyDescriptor.java
+++ b/src/main/java/org/jenkinsci/plugins/authorizeproject/AuthorizeProjectStrategyDescriptor.java
@@ -31,7 +31,7 @@ import java.util.ArrayList;
 import java.util.List;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
-import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerRequest2;
 
 /**
  * Base {@link Descriptor} class for {@link AuthorizeProjectStrategy} instances.
@@ -91,7 +91,7 @@ public abstract class AuthorizeProjectStrategyDescriptor extends Descriptor<Auth
      * Invoked when configuration is submitted from "Configure Global Security" as a child of {@link ProjectQueueItemAuthenticator}.
      * You should call save() by yourself.
      */
-    public void configureFromGlobalSecurity(StaplerRequest req, JSONObject js) throws FormException {}
+    public void configureFromGlobalSecurity(StaplerRequest2 req, JSONObject js) throws FormException {}
 
     /**
      * @return this strategy can be enabled by default.

--- a/src/main/java/org/jenkinsci/plugins/authorizeproject/AuthorizeProjectUtil.java
+++ b/src/main/java/org/jenkinsci/plugins/authorizeproject/AuthorizeProjectUtil.java
@@ -30,7 +30,7 @@ import hudson.model.Descriptor;
 import hudson.model.Descriptor.FormException;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
-import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerRequest2;
 
 /**
  *
@@ -40,7 +40,7 @@ public class AuthorizeProjectUtil {
      * Create a new {@link Describable} object from user inputs.
      */
     public static <T extends Describable<?>> T bindJSONWithDescriptor(
-            StaplerRequest req, JSONObject formData, String fieldName, Class<T> clazz) throws FormException {
+            StaplerRequest2 req, JSONObject formData, String fieldName, Class<T> clazz) throws FormException {
         formData = formData.getJSONObject(fieldName);
         if (formData == null || formData.isNullObject()) {
             return null;

--- a/src/main/java/org/jenkinsci/plugins/authorizeproject/ConfigurationPermissionEnforcer.java
+++ b/src/main/java/org/jenkinsci/plugins/authorizeproject/ConfigurationPermissionEnforcer.java
@@ -12,7 +12,7 @@ import net.sf.json.JSONObject;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerRequest2;
 
 /**
  * A dummy {@link JobProperty} responsible for providing the {@link AuthorizeProjectStrategy} with a veto over job
@@ -47,7 +47,7 @@ public class ConfigurationPermissionEnforcer extends JobProperty<Job<?, ?>> {
          * {@inheritDoc}
          */
         @Override
-        public JobProperty<?> newInstance(@NonNull StaplerRequest req, JSONObject formData) throws FormException {
+        public JobProperty<?> newInstance(@NonNull StaplerRequest2 req, JSONObject formData) throws FormException {
             Job<?, ?> job = req.findAncestorObject(Job.class);
             AccessControlled context = req.findAncestorObject(AccessControlled.class);
             checkConfigurePermission(job, context);

--- a/src/main/java/org/jenkinsci/plugins/authorizeproject/GlobalQueueItemAuthenticator.java
+++ b/src/main/java/org/jenkinsci/plugins/authorizeproject/GlobalQueueItemAuthenticator.java
@@ -8,10 +8,10 @@ import java.util.stream.Collectors;
 import jenkins.security.QueueItemAuthenticator;
 import jenkins.security.QueueItemAuthenticatorDescriptor;
 import net.sf.json.JSONObject;
-import org.acegisecurity.Authentication;
 import org.jenkinsci.plugins.authorizeproject.strategy.AnonymousAuthorizationStrategy;
 import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerRequest2;
+import org.springframework.security.core.Authentication;
 
 /**
  * A global default authenticator to allow changing the default for all projects.
@@ -31,7 +31,7 @@ public class GlobalQueueItemAuthenticator extends QueueItemAuthenticator {
     }
 
     @Override
-    public Authentication authenticate(Queue.Item item) {
+    public Authentication authenticate2(Queue.Item item) {
         return strategy != null && item.task instanceof Job ? strategy.authenticate((Job<?, ?>) item.task, item) : null;
     }
 
@@ -65,13 +65,13 @@ public class GlobalQueueItemAuthenticator extends QueueItemAuthenticator {
 
         /**
          * Creates new {@link GlobalQueueItemAuthenticator} from inputs.
-         * This is required to call {@link hudson.model.Descriptor#newInstance(StaplerRequest, JSONObject)}
+         * This is required to call {@link hudson.model.Descriptor#newInstance(StaplerRequest2, JSONObject)}
          * of {@link AuthorizeProjectProperty}.
          *
-         * @see hudson.model.Descriptor#newInstance(org.kohsuke.stapler.StaplerRequest, net.sf.json.JSONObject)
+         * @see hudson.model.Descriptor#newInstance(org.kohsuke.stapler.StaplerRequest2, net.sf.json.JSONObject)
          */
         @Override
-        public GlobalQueueItemAuthenticator newInstance(StaplerRequest req, JSONObject formData) throws FormException {
+        public GlobalQueueItemAuthenticator newInstance(StaplerRequest2 req, JSONObject formData) throws FormException {
             if (formData == null || formData.isNullObject()) {
                 return null;
             }

--- a/src/main/java/org/jenkinsci/plugins/authorizeproject/ProjectQueueItemAuthenticator.java
+++ b/src/main/java/org/jenkinsci/plugins/authorizeproject/ProjectQueueItemAuthenticator.java
@@ -41,9 +41,9 @@ import jenkins.security.QueueItemAuthenticator;
 import jenkins.security.QueueItemAuthenticatorConfiguration;
 import jenkins.security.QueueItemAuthenticatorDescriptor;
 import net.sf.json.JSONObject;
-import org.acegisecurity.Authentication;
 import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerRequest2;
+import org.springframework.security.core.Authentication;
 
 /**
  * Authorize builds of projects configured with {@link AuthorizeProjectProperty}.
@@ -90,11 +90,11 @@ public class ProjectQueueItemAuthenticator extends QueueItemAuthenticator {
     }
 
     /**
-     * @see jenkins.security.QueueItemAuthenticator#authenticate(hudson.model.Queue.Item)
+     * @see jenkins.security.QueueItemAuthenticator#authenticate2(hudson.model.Queue.Item)
      */
     @Override
     @CheckForNull
-    public Authentication authenticate(Queue.Item item) {
+    public Authentication authenticate2(Queue.Item item) {
         if (!(item.task instanceof Job)) {
             return null;
         }
@@ -179,10 +179,11 @@ public class ProjectQueueItemAuthenticator extends QueueItemAuthenticator {
          * @param formData the form data.
          * @return the authenticator.
          * @throws hudson.model.Descriptor.FormException if the submitted form is invalid.
-         * @see hudson.model.Descriptor#newInstance(org.kohsuke.stapler.StaplerRequest, net.sf.json.JSONObject)
+         * @see hudson.model.Descriptor#newInstance(org.kohsuke.stapler.StaplerRequest2, net.sf.json.JSONObject)
          */
         @Override
-        public ProjectQueueItemAuthenticator newInstance(StaplerRequest req, JSONObject formData) throws FormException {
+        public ProjectQueueItemAuthenticator newInstance(StaplerRequest2 req, JSONObject formData)
+                throws FormException {
             Set<String> enabledStrategies = new HashSet<>();
             Set<String> disabledStrategies = new HashSet<>();
 

--- a/src/main/java/org/jenkinsci/plugins/authorizeproject/strategy/AnonymousAuthorizationStrategy.java
+++ b/src/main/java/org/jenkinsci/plugins/authorizeproject/strategy/AnonymousAuthorizationStrategy.java
@@ -28,10 +28,10 @@ import hudson.Extension;
 import hudson.model.Job;
 import hudson.model.Queue;
 import jenkins.model.Jenkins;
-import org.acegisecurity.Authentication;
 import org.jenkinsci.plugins.authorizeproject.AuthorizeProjectStrategy;
 import org.jenkinsci.plugins.authorizeproject.AuthorizeProjectStrategyDescriptor;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.springframework.security.core.Authentication;
 
 /**
  * Run builds as anonymous.
@@ -51,7 +51,7 @@ public class AnonymousAuthorizationStrategy extends AuthorizeProjectStrategy {
      */
     @Override
     public Authentication authenticate(Job<?, ?> project, Queue.Item item) {
-        return Jenkins.ANONYMOUS;
+        return Jenkins.ANONYMOUS2;
     }
 
     /**

--- a/src/main/java/org/jenkinsci/plugins/authorizeproject/strategy/SystemAuthorizationStrategy.java
+++ b/src/main/java/org/jenkinsci/plugins/authorizeproject/strategy/SystemAuthorizationStrategy.java
@@ -32,7 +32,6 @@ import hudson.security.AccessControlled;
 import hudson.util.FormValidation;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
-import org.acegisecurity.Authentication;
 import org.jenkinsci.plugins.authorizeproject.AuthorizeProjectProperty;
 import org.jenkinsci.plugins.authorizeproject.AuthorizeProjectStrategy;
 import org.jenkinsci.plugins.authorizeproject.AuthorizeProjectStrategyDescriptor;
@@ -40,12 +39,13 @@ import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
-import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerRequest2;
+import org.springframework.security.core.Authentication;
 
 /**
- * Run builds as {@link ACL#SYSTEM}. Using this strategy becomes important when
+ * Run builds as {@link ACL#SYSTEM2}. Using this strategy becomes important when
  * {@link org.jenkinsci.plugins.authorizeproject.GlobalQueueItemAuthenticator}
- * is forcing jobs to a user other than {@link ACL#SYSTEM}.
+ * is forcing jobs to a user other than {@link ACL#SYSTEM2}.
  *
  * @since 1.2.0
  */
@@ -61,7 +61,7 @@ public class SystemAuthorizationStrategy extends AuthorizeProjectStrategy {
      */
     @Override
     public Authentication authenticate(Job<?, ?> job, Queue.Item item) {
-        return ACL.SYSTEM;
+        return ACL.SYSTEM2;
     }
 
     /**
@@ -176,7 +176,7 @@ public class SystemAuthorizationStrategy extends AuthorizeProjectStrategy {
          * {@inheritDoc}
          */
         @Override
-        public void configureFromGlobalSecurity(StaplerRequest req, JSONObject js) throws FormException {
+        public void configureFromGlobalSecurity(StaplerRequest2 req, JSONObject js) throws FormException {
             setPermitReconfiguration(js.getBoolean("permitReconfiguration"));
         }
 
@@ -184,7 +184,7 @@ public class SystemAuthorizationStrategy extends AuthorizeProjectStrategy {
          * {@inheritDoc}
          */
         @Override
-        public SystemAuthorizationStrategy newInstance(StaplerRequest req, JSONObject formData) throws FormException {
+        public SystemAuthorizationStrategy newInstance(StaplerRequest2 req, JSONObject formData) throws FormException {
             SystemAuthorizationStrategy result = (SystemAuthorizationStrategy) super.newInstance(req, formData);
             Jenkins instance = Jenkins.get();
             if (!instance.hasPermission(Jenkins.RUN_SCRIPTS)) {

--- a/src/main/java/org/jenkinsci/plugins/authorizeproject/strategy/TriggeringUsersAuthorizationStrategy.java
+++ b/src/main/java/org/jenkinsci/plugins/authorizeproject/strategy/TriggeringUsersAuthorizationStrategy.java
@@ -38,11 +38,11 @@ import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import jenkins.model.Jenkins;
-import org.acegisecurity.Authentication;
-import org.acegisecurity.userdetails.UsernameNotFoundException;
 import org.jenkinsci.plugins.authorizeproject.AuthorizeProjectStrategy;
 import org.jenkinsci.plugins.authorizeproject.AuthorizeProjectStrategyDescriptor;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 
 /**
  * Run builds as a user who triggered the build.
@@ -67,16 +67,16 @@ public class TriggeringUsersAuthorizationStrategy extends AuthorizeProjectStrate
         if (cause != null) {
             User u = User.get(cause.getUserId(), false, Map.of());
             if (u == null) {
-                return Jenkins.ANONYMOUS;
+                return Jenkins.ANONYMOUS2;
             }
             try {
-                return u.impersonate();
+                return u.impersonate2();
             } catch (UsernameNotFoundException e) {
                 LOGGER.log(
                         Level.WARNING,
                         String.format("Invalid User %s. Falls back to anonymous.", cause.getUserId()),
                         e);
-                return Jenkins.ANONYMOUS;
+                return Jenkins.ANONYMOUS2;
             }
         }
         return null;

--- a/src/test/java/org/jenkinsci/plugins/authorizeproject/GlobalQueueItemAuthenticatorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/authorizeproject/GlobalQueueItemAuthenticatorTest.java
@@ -34,14 +34,14 @@ public class GlobalQueueItemAuthenticatorTest {
         DescribableList<QueueItemAuthenticator, QueueItemAuthenticatorDescriptor> authenticators =
                 QueueItemAuthenticatorConfiguration.get().getAuthenticators();
         authenticators.remove(GlobalQueueItemAuthenticator.class);
-        // if not configured, run in SYSTEM privilege.
+        // if not configured, run in SYSTEM2 privilege.
         {
             FreeStyleProject p = j.createFreeStyleProject();
             AuthorizationCheckBuilder checker = new AuthorizationCheckBuilder();
             p.getBuildersList().add(checker);
 
             j.assertBuildStatusSuccess(p.scheduleBuild2(0));
-            assertEquals(ACL.SYSTEM, checker.authentication);
+            assertEquals(ACL.SYSTEM2, checker.authentication);
         }
 
         authenticators.add(new GlobalQueueItemAuthenticator(
@@ -70,7 +70,7 @@ public class GlobalQueueItemAuthenticatorTest {
             p.addProperty(new AuthorizeProjectProperty(new AnonymousAuthorizationStrategy()));
 
             j.assertBuildStatusSuccess(p.scheduleBuild2(0));
-            assertEquals(Jenkins.ANONYMOUS, checker.authentication);
+            assertEquals(Jenkins.ANONYMOUS2, checker.authentication);
         }
 
         // if configured ProjectQueueItemAuthenticator wrong, run fall through to GlobalQueueItemAuthenticator.

--- a/src/test/java/org/jenkinsci/plugins/authorizeproject/strategy/AnonymousAuthorizationStrategyTest.java
+++ b/src/test/java/org/jenkinsci/plugins/authorizeproject/strategy/AnonymousAuthorizationStrategyTest.java
@@ -46,10 +46,10 @@ public class AnonymousAuthorizationStrategyTest {
         AuthorizationCheckBuilder checker = new AuthorizationCheckBuilder();
         p.getBuildersList().add(checker);
 
-        // if not configured, run in SYSTEM privilege.
+        // if not configured, run in SYSTEM2 privilege.
         {
             j.assertBuildStatusSuccess(p.scheduleBuild2(0));
-            assertEquals(ACL.SYSTEM, checker.authentication);
+            assertEquals(ACL.SYSTEM2, checker.authentication);
         }
 
         p.addProperty(new AuthorizeProjectProperty(new AnonymousAuthorizationStrategy()));
@@ -57,7 +57,7 @@ public class AnonymousAuthorizationStrategyTest {
         // if configured, run in ANONYMOUS privilege.
         {
             j.assertBuildStatusSuccess(p.scheduleBuild2(0));
-            assertEquals(Jenkins.ANONYMOUS, checker.authentication);
+            assertEquals(Jenkins.ANONYMOUS2, checker.authentication);
         }
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/authorizeproject/strategy/SystemAuthorizationStrategyTest.java
+++ b/src/test/java/org/jenkinsci/plugins/authorizeproject/strategy/SystemAuthorizationStrategyTest.java
@@ -44,6 +44,7 @@ import hudson.model.Item;
 import hudson.model.ParametersDefinitionProperty;
 import hudson.model.StringParameterDefinition;
 import hudson.security.GlobalMatrixAuthorizationStrategy;
+import jakarta.servlet.ServletRequest;
 import java.io.ByteArrayInputStream;
 import java.io.StringWriter;
 import java.net.URL;
@@ -185,7 +186,7 @@ public class SystemAuthorizationStrategyTest {
                 new URL(wc.getContextPath() + String.format("%s/config.xml", destProject.getUrl())), HttpMethod.POST);
         req.setAdditionalHeader(
                 j.jenkins.getCrumbIssuer().getCrumbRequestField(),
-                j.jenkins.getCrumbIssuer().getCrumb(null));
+                j.jenkins.getCrumbIssuer().getCrumb((ServletRequest) null));
         req.setRequestBody(configXml);
         wc.getPage(req);
 
@@ -235,7 +236,7 @@ public class SystemAuthorizationStrategyTest {
                 new URL(wc.getContextPath() + String.format("%s/config.xml", destProject.getUrl())), HttpMethod.POST);
         req.setAdditionalHeader(
                 j.jenkins.getCrumbIssuer().getCrumbRequestField(),
-                j.jenkins.getCrumbIssuer().getCrumb(null));
+                j.jenkins.getCrumbIssuer().getCrumb((ServletRequest) null));
         req.setRequestBody(configXml);
 
         assertThrows(FailingHttpStatusCodeException.class, () -> wc.getPage(req));

--- a/src/test/java/org/jenkinsci/plugins/authorizeproject/strategy/TriggeringUsersAuthorizationStrategyTest.java
+++ b/src/test/java/org/jenkinsci/plugins/authorizeproject/strategy/TriggeringUsersAuthorizationStrategyTest.java
@@ -36,7 +36,6 @@ import hudson.tasks.BuildTrigger;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import jenkins.model.Jenkins;
-import org.acegisecurity.providers.UsernamePasswordAuthenticationToken;
 import org.jenkinsci.plugins.authorizeproject.AuthorizeProjectProperty;
 import org.jenkinsci.plugins.authorizeproject.testutil.AuthorizationCheckBuilder;
 import org.jenkinsci.plugins.authorizeproject.testutil.AuthorizeProjectJenkinsRule;
@@ -46,6 +45,7 @@ import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.JenkinsRule.WebClient;
 import org.jvnet.hudson.test.recipes.LocalData;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 
 public class TriggeringUsersAuthorizationStrategyTest {
     @Rule
@@ -67,7 +67,7 @@ public class TriggeringUsersAuthorizationStrategyTest {
         AuthorizationCheckBuilder checker = new AuthorizationCheckBuilder();
         p.getBuildersList().add(checker);
 
-        // if not configured, run in SYSTEM privilege.
+        // if not configured, run in SYSTEM2 privilege.
         {
             assertNull(p.getLastBuild());
             WebClient wc = j.createWebClient();
@@ -77,7 +77,7 @@ public class TriggeringUsersAuthorizationStrategyTest {
             assertNotNull(b);
             j.assertBuildStatusSuccess(b);
 
-            assertEquals(ACL.SYSTEM, checker.authentication);
+            assertEquals(ACL.SYSTEM2, checker.authentication);
             b.delete();
         }
 
@@ -93,7 +93,7 @@ public class TriggeringUsersAuthorizationStrategyTest {
             assertNotNull(b);
             j.assertBuildStatusSuccess(b);
 
-            assertEquals(Jenkins.ANONYMOUS, checker.authentication);
+            assertEquals(Jenkins.ANONYMOUS2, checker.authentication);
             b.delete();
         }
 
@@ -167,7 +167,7 @@ public class TriggeringUsersAuthorizationStrategyTest {
         AuthorizationCheckBuilder checker = new AuthorizationCheckBuilder();
         p.getBuildersList().add(checker);
 
-        try (ACLContext ignored = ACL.as(new UsernamePasswordAuthenticationToken("validuser", "validuser"))) {
+        try (ACLContext ignored = ACL.as2(new UsernamePasswordAuthenticationToken("validuser", "validuser"))) {
             j.assertBuildStatusSuccess(
                     p.scheduleBuild2(0, new Cause.UserIdCause()).get(10, TimeUnit.SECONDS));
         }
@@ -176,10 +176,10 @@ public class TriggeringUsersAuthorizationStrategyTest {
         // In case of specifying an invalid user,
         // falls back to anonymous.
         // And the build should not be blocked.
-        try (ACLContext ignored = ACL.as(new UsernamePasswordAuthenticationToken("invaliduser", "invaliduser"))) {
+        try (ACLContext ignored = ACL.as2(new UsernamePasswordAuthenticationToken("invaliduser", "invaliduser"))) {
             j.assertBuildStatusSuccess(
                     p.scheduleBuild2(0, new Cause.UserIdCause()).get(10, TimeUnit.SECONDS));
         }
-        assertEquals(Jenkins.ANONYMOUS, checker.authentication);
+        assertEquals(Jenkins.ANONYMOUS2, checker.authentication);
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/authorizeproject/testutil/AuthorizationCheckBuilder.java
+++ b/src/test/java/org/jenkinsci/plugins/authorizeproject/testutil/AuthorizationCheckBuilder.java
@@ -32,7 +32,7 @@ import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.Builder;
 import java.io.IOException;
 import jenkins.model.Jenkins;
-import org.acegisecurity.Authentication;
+import org.springframework.security.core.Authentication;
 
 public class AuthorizationCheckBuilder extends Builder {
 
@@ -48,7 +48,7 @@ public class AuthorizationCheckBuilder extends Builder {
     @Override
     public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener)
             throws InterruptedException, IOException {
-        authentication = Jenkins.getAuthentication();
+        authentication = Jenkins.getAuthentication2();
         return true;
     }
 

--- a/src/test/java/org/jenkinsci/plugins/authorizeproject/testutil/SecurityRealmWithUserFilter.java
+++ b/src/test/java/org/jenkinsci/plugins/authorizeproject/testutil/SecurityRealmWithUserFilter.java
@@ -26,8 +26,8 @@ package org.jenkinsci.plugins.authorizeproject.testutil;
 
 import hudson.security.SecurityRealm;
 import java.util.List;
-import org.acegisecurity.userdetails.UsernameNotFoundException;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 
 /**
  * Wraps other {@link SecurityRealm},
@@ -48,14 +48,14 @@ public class SecurityRealmWithUserFilter extends SecurityRealm {
     public SecurityComponents createSecurityComponents() {
         final SecurityComponents baseComponent = baseSecurityRealm.createSecurityComponents();
         return new SecurityComponents(
-                baseComponent.manager,
+                baseComponent.manager2,
                 username -> {
                     if (!validUserList.contains(username)) {
                         throw new UsernameNotFoundException(
                                 String.format("%s is not listed as valid username.", username));
                     }
-                    return baseComponent.userDetails.loadUserByUsername(username);
+                    return baseComponent.userDetails2.loadUserByUsername(username);
                 },
-                baseComponent.rememberMe);
+                baseComponent.rememberMe2);
     }
 }


### PR DESCRIPTION
Note that the Acegi migration will break the [Ownership plugin](https://plugins.jenkins.io/ownership/), but that plugin has unresolved security vulnerabilities and has not been updated in over 5 years. If this is a problem, then the Ownership plugin can simply be adopted and modernized.